### PR TITLE
Fix Analytics DB env var

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - pg
     restart: unless-stopped
     environment:
-      DATABASE_DSN: "postgresql://catalog_admin:P@ssw0rd!@pg:5432/catalog"
+      ConnectionStrings__AnalyticsDb: "postgresql://catalog_admin:P@ssw0rd!@pg:5432/catalog"
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
## Summary
- fix environment variable name for analytics service in docker-compose

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442543e30c832eaec160aa26e95d1e