### PR TITLE
Fix Auth port config

### DIFF
--- a/services/Auth/Program.cs
+++ b/services/Auth/Program.cs
@@ -9,7 +9,10 @@ using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.WebHost.UseUrls("http://0.0.0.0:80");
+// Allow the listening port to be overridden via the PORT environment variable
+// so the container can adapt to different hosting environments. Default is 80.
+var port = Environment.GetEnvironmentVariable("PORT") ?? "80";
+builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
 
 builder.Services.AddDbContext<AuthDbContext>(options =>
 {

--- a/services/Auth/README.md
+++ b/services/Auth/README.md
@@ -4,6 +4,7 @@ This service provides authentication via Duende IdentityServer on .NET 8. It sto
 
 ## 环境变量
 - `ConnectionStrings__AuthDb`: PostgreSQL connection string, e.g. `Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!`.
+- `PORT`: Optional HTTP port for the service (default `80`).
 
 ## Database Schema
 The default schema is `auth` and will contain IdentityServer tables for persisted grants and configuration.


### PR DESCRIPTION
## Summary
- make Auth service listen on PORT env var if set
- document PORT env var in Auth README

## Testing
- `pytest -q` in `services/Analytics`
- `go test ./...` in `services/Payment` *(fails: Forbidden download)*
- `./gradlew test` in `services/Security` *(failed to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_684427cab434832ea0ec223c4d962d15