### PR TITLE
Add Docker Compose files for each service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ From the `services` directory you can spin up the entire stack:
 docker compose up --build
 ```
 
-Run a service individually with Docker:
+Run a single service for local testing using its Docker Compose file:
 
 ```bash
-cd services/Catalog
-docker build -t catalog.api .
-docker run -p 5000:80 catalog.api
+cd services/<ServiceName>
+docker compose up --build
 ```
 When using the Security service, the Gradle wrapper JAR is downloaded
 automatically on first run. Simply execute `./gradlew` in `services/Security`.

--- a/services/Analytics/README.md
+++ b/services/Analytics/README.md
@@ -32,18 +32,11 @@ poetry run uvicorn app.main:app --reload
 
 ## Docker
 
-Build and run using Docker:
+Run the service with Docker Compose from this directory:
 ```bash
-docker build -t analytics.api .
-docker run -p 8000:8000 \
-  -e ConnectionStrings__AnalyticsDb="Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!" \
-  analytics.api
+docker compose up --build
 ```
-You can also spin up the whole stack with the root `docker-compose.yml`:
-```bash
-cd ..
-docker compose up analytics.api
-```
+You can still use the root `docker-compose.yml` to start the entire stack if needed.
 
 Refer to `openapi.yaml` for the complete API specification.
 

--- a/services/Analytics/docker-compose.yml
+++ b/services/Analytics/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: analytics-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  analytics.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: analytics.api:dev
+    container_name: analytics-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ConnectionStrings__AnalyticsDb: "postgresql://catalog_admin:P@ssw0rd!@pg:5432/catalog"
+    ports:
+      - "8000:8000"
+
+volumes:
+  pgdata:

--- a/services/Auth/README.md
+++ b/services/Auth/README.md
@@ -18,9 +18,9 @@ The project can be generated or updated using the `dotnet-idsvr` CLI tool.
    ```bash
    dotnet run --project Auth.csproj
    ```
-3. Or run with Docker Compose from the `services` folder:
+3. Or run using the local Docker Compose file:
    ```bash
-   docker compose up auth.api
+   docker compose up --build
    ```
 
 ## Multi-tenant Notes

--- a/services/Auth/docker-compose.yml
+++ b/services/Auth/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: auth-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  auth.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: auth.api:dev
+    container_name: auth-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__AuthDb: "Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!"
+    ports:
+      - "7000:80"
+
+volumes:
+  pgdata:

--- a/services/Gateway/README.md
+++ b/services/Gateway/README.md
@@ -17,4 +17,7 @@ Each microservice is available under the `/api/v1/` prefix, for example:
 
 Global plugins enable JWT authentication, ACL based authorisation, rate limiting and Prometheus metrics. New services are added by updating `kong.yml` and reloading Kong (handled by the CI pipeline).
 
-Run the gateway with the rest of the stack via `docker compose up` from the `services` directory.
+You can run the full stack from the `services` directory, or start a small test setup from this folder:
+```bash
+docker compose up --build
+```

--- a/services/Gateway/docker-compose.yml
+++ b/services/Gateway/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: gateway-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  catalog.api:
+    build:
+      context: ../Catalog
+      dockerfile: Dockerfile
+    image: catalog.api:dev
+    container_name: catalog-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__CatalogDb: "Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!"
+    ports:
+      - "5000:80"
+
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: kong.gateway:dev
+    container_name: gateway
+    depends_on:
+      - catalog.api
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /kong/kong.yml
+    volumes:
+      - ./kong.yml:/kong/kong.yml:ro
+    ports:
+      - "80:8000"
+      - "8001:8001"
+
+volumes:
+  pgdata:

--- a/services/Order/README.md
+++ b/services/Order/README.md
@@ -15,3 +15,9 @@
 
 ## Quartz
 `Program.cs` 中已注册 Quartz，可在 `Quartz` 任务中实现后台作业。
+
+## Docker Compose
+在此目录运行以下命令以启动服务与本地 PostgreSQL：
+```bash
+docker compose up --build
+```

--- a/services/Order/docker-compose.yml
+++ b/services/Order/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: order-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  order.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: order.api:dev
+    container_name: order-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__OrderDb: "Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!"
+    ports:
+      - "5002:80"
+
+volumes:
+  pgdata:

--- a/services/Payment/README.md
+++ b/services/Payment/README.md
@@ -25,3 +25,7 @@ This service handles payment processing for the e-commerce platform. It is imple
    ```bash
    docker build -t payment.api .
    ```
+4. Or run locally with Docker Compose:
+   ```bash
+   docker compose up --build
+   ```

--- a/services/Payment/docker-compose.yml
+++ b/services/Payment/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: payment-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  payment.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: payment.api:dev
+    container_name: payment-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ConnectionStrings__PaymentDb: "Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!"
+    ports:
+      - "7001:7001"
+      - "7002:8080"
+
+volumes:
+  pgdata:

--- a/services/Security/README.md
+++ b/services/Security/README.md
@@ -18,6 +18,10 @@ See [Minimum.md](Minimum.md) for the minimal integration information.
    ```bash
    docker build -t security.api .
    ```
+5. Or run locally with Docker Compose:
+   ```bash
+   docker compose up --build
+   ```
 
 ## Database
 

--- a/services/Security/docker-compose.yml
+++ b/services/Security/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: security-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  security.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: security.api:dev
+    container_name: security-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://pg:5432/catalog
+      SPRING_DATASOURCE_USERNAME: catalog_admin
+      SPRING_DATASOURCE_PASSWORD: P@ssw0rd!
+      SPRING_DATASOURCE_HIKARI_SCHEMA: security
+    ports:
+      - "8082:8082"
+
+volumes:
+  pgdata:

--- a/services/Shipping/README.md
+++ b/services/Shipping/README.md
@@ -19,6 +19,10 @@ This microservice manages shipment information for orders. It is implemented wit
    ```bash
    docker build -t shipping.api .
    ```
+4. Run with Docker Compose:
+   ```bash
+   docker compose up --build
+   ```
 
 Recurring jobs are configured via Hangfire. The sample job `CheckPendingShipmentsJob` runs every minute.
 

--- a/services/Shipping/docker-compose.yml
+++ b/services/Shipping/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: shipping-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  shipping.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: shipping.api:dev
+    container_name: shipping-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__ShippingDb: "Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!"
+    ports:
+      - "5004:80"
+
+volumes:
+  pgdata:

--- a/services/User/README.md
+++ b/services/User/README.md
@@ -15,10 +15,10 @@ The project targets .NET 8 and references Rebus and Quartz packages. You can bui
 docker build -t user.api .
 ```
 
-Then run with:
+Then run with Docker Compose:
 
 ```bash
-docker run -p 5003:80 user.api
+docker compose up --build
 ```
 
 See `Minimum.md` for integration details and `openapi.yaml` for the full API contract.

--- a/services/User/docker-compose.yml
+++ b/services/User/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16-alpine
+    container_name: user-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catalog_admin
+      POSTGRES_PASSWORD: P@ssw0rd!
+      POSTGRES_DB: catalog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  user.api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: user.api:dev
+    container_name: user-api
+    depends_on:
+      - pg
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__UserDb: "Host=pg;Port=5432;Database=catalog;Username=catalog_admin;Password=P@ssw0rd!"
+    ports:
+      - "5003:80"
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- add per-service `docker-compose.yml` for easier local testing
- document the new workflow in each service README
- update root README with single service compose instructions

## Testing
- `dotnet test` *(fails: command not found)*
- `go test ./...` in Payment *(fails: dependency download forbidden)*
- `poetry run pytest --cov` in Analytics *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68444be9e630832ea021c89673a1d63e