### PR TITLE
Fix Payment test

### DIFF
--- a/services/Payment/cmd/server/main_test.go
+++ b/services/Payment/cmd/server/main_test.go
@@ -1,24 +1,34 @@
 package main
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    pb "payment/api"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	pb "github.com/QuanQLee/e-commerce-project/services/Payment/api"
 )
 
 func TestCreatePayment(t *testing.T) {
-    s := &server{}
-    req := &pb.CreatePaymentRequest{OrderId: "1", Amount: 100}
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	if err := db.AutoMigrate(&Payment{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	s := &server{db: db}
+	req := &pb.CreatePaymentRequest{OrderId: "1", Amount: 100}
 
-    resp, err := s.CreatePayment(context.Background(), req)
-    if err != nil {
-        t.Fatalf("CreatePayment returned error: %v", err)
-    }
-    if resp.PaymentId != "demo" {
-        t.Errorf("expected payment_id 'demo', got %q", resp.PaymentId)
-    }
-    if resp.Status != "created" {
-        t.Errorf("expected status 'created', got %q", resp.Status)
-    }
+	resp, err := s.CreatePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreatePayment returned error: %v", err)
+	}
+	if resp.PaymentId == "" {
+		t.Errorf("expected non-empty payment_id")
+	}
+	if resp.Status != "PAID" {
+		t.Errorf("expected status 'PAID', got %q", resp.Status)
+	}
 }


### PR DESCRIPTION
## Summary
- update import path in Payment service tests
- adjust `CreatePayment` test expectations to match runtime behavior
- initialize an in-memory sqlite database for testing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684a497b86d8832ea359db705ee25ce8