### PR TITLE
Align service ports across docs and code

### DIFF
--- a/services/Analytics/run.py
+++ b/services/Analytics/run.py
@@ -1,4 +1,4 @@
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="127.0.0.1", port=8004, reload=True)
+    uvicorn.run("app.main:app", host="127.0.0.1", port=8000, reload=True)

--- a/services/Auth/Minimum.md
+++ b/services/Auth/Minimum.md
@@ -3,7 +3,7 @@
 This document lists the minimal information required to integrate with the Auth microservice.
 
 ## Base URL
-- `http://<host>:5003`
+- `http://<host>:7000`
 
 ## Required Headers
 - `Content-Type: application/x-www-form-urlencoded`

--- a/services/Shipping/Minimum.md
+++ b/services/Shipping/Minimum.md
@@ -4,7 +4,7 @@ This document lists the minimal information needed to integrate with the Shippin
 
 ## Base URL
 
-- **HTTP**: `http://<host>:5003`
+- **HTTP**: `http://<host>:5004`
 
 ## Required Headers
 

--- a/services/Shipping/README.md
+++ b/services/Shipping/README.md
@@ -6,7 +6,7 @@ This microservice manages shipment information for orders. It is implemented wit
 
 - **Database**: PostgreSQL schema `shipping`.
 - **Environment Variable** `ConnectionStrings__ShippingDb` containing the PostgreSQL connection string.
-- **Port**: `5003` for HTTP.
+- **Port**: `5004` for HTTP.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- update Auth Minimum documentation to use port 7000
- correct Shipping documentation to use port 5004
- switch analytics run script to default to port 8000

## Testing
- `pip install fastapi uvicorn pandas sqlalchemy asyncpg apscheduler prometheus-client pytest pytest-asyncio httpx aiosqlite python-dotenv --break-system-packages`
- `pip install "httpx==0.27.*" --break-system-packages`
- `DATABASE_URL=sqlite+aiosqlite:///:memory: PYTHONPATH=services/Analytics pytest services/Analytics/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4980df30832eb5071535d0a3ac26