### PR TITLE
Fix go_package comment

### DIFF
--- a/services/Payment/api/payment.proto
+++ b/services/Payment/api/payment.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package payment.v1;
 
-// ***关键***：go_package 必须写到 “模块根 + /api; 包名”
+// The go_package option specifies the import path for the generated Go code.
 option go_package = "github.com/QuanQLee/e-commerce-project/services/Payment/api;api";
 
 service PaymentService {


### PR DESCRIPTION
## Summary
- update Payment service proto comment to clearly explain go_package

## Testing
- `go test ./...` *(fails: package payment/api is not in std)*
- `for proj in services/*/*.Tests/*.csproj; do dotnet test "$proj" --no-build; done` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a4981b980832e8b35e410523f91bc