### PR TITLE
Switch gateway container to Kong 3.x

### DIFF
--- a/services/Gateway/Dockerfile
+++ b/services/Gateway/Dockerfile
@@ -1,36 +1,16 @@
-# -------------------- 1. 构建阶段 --------------------
-# 用官方 OpenJDK 17 slim 镜像（改成你用的版本）
-FROM openjdk:17-jdk-slim AS build
+FROM kong:3
 
-# 1.1 工作目录
-WORKDIR /app
+# Copy declarative configuration
+COPY kong.yml /kong/kong.yml
 
-# 1.2 首先拷入 Gradle Wrapper，保证脚本在这里
-COPY gradlew ./
-COPY gradle/wrapper/ gradle/wrapper/
+# Use the bundled nginx user
+USER root
 
-# 1.3 授可执行权限
-RUN chmod +x gradlew
+# Set Kong to run in DB-less mode with the provided config
+ENV KONG_DATABASE=off \
+    KONG_DECLARATIVE_CONFIG=/kong/kong.yml
 
-# 1.4 拷入 Gradle 配置文件（build.gradle、settings.gradle）
-COPY build.gradle settings.gradle ./
+# Expose standard Kong ports
+EXPOSE 8000 8443 8001 8444
 
-# 1.5 拷源码文件
-COPY src/ src/
-
-# 1.6 用 Wrapper 构建 Spring Boot 可执行包
-RUN ./gradlew clean bootJar --no-daemon
-
-# -------------------- 2. 运行阶段 --------------------
-FROM openjdk:17-jdk-slim
-
-WORKDIR /app
-
-# 2.1 从 build 阶段拷输出的 JAR
-COPY --from=build /app/build/libs/*.jar app.jar
-
-# 2.2 暴露端口（改成服务实际端口）
-EXPOSE 8080
-
-# 2.3 启动命令
-ENTRYPOINT ["java","-jar","app.jar"]
+# Use default entrypoint/cmd from base image

--- a/services/Gateway/docker-compose.yml
+++ b/services/Gateway/docker-compose.yml
@@ -36,11 +36,6 @@ services:
     container_name: gateway
     depends_on:
       - catalog.api
-    environment:
-      KONG_DATABASE: "off"
-      KONG_DECLARATIVE_CONFIG: /kong/kong.yml
-    volumes:
-      - ./kong.yml:/kong/kong.yml:ro
     ports:
       - "80:8000"
       - "8001:8001"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -145,11 +145,6 @@ services:
       - analytics.api
       - auth.api
       - security.api
-    environment:
-      KONG_DATABASE: "off"
-      KONG_DECLARATIVE_CONFIG: /kong/kong.yml
-    volumes:
-      - ./Gateway/kong.yml:/kong/kong.yml:ro
     ports:
       - "80:8000"
       - "8001:8001"


### PR DESCRIPTION
## Summary
- rebuild the Gateway Dockerfile on `kong:3`
- use built image in compose without extra env/volume config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684a5a9c151c832e88a7666a184f37b3