### PR TITLE
Add MIT license and fix Payment tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The E-Commerce Project Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ automatically on first run. Simply execute `./gradlew` in `services/Security`.
 
 ## Service Documentation
 
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/services/Payment/cmd/server/main_test.go
+++ b/services/Payment/cmd/server/main_test.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    pb "payment/api"
+	pb "github.com/QuanQLee/e-commerce-project/services/Payment/api"
 )
 
 func TestCreatePayment(t *testing.T) {
-    s := &server{}
-    req := &pb.CreatePaymentRequest{OrderId: "1", Amount: 100}
+	s := &server{db: initDB()}
+	req := &pb.CreatePaymentRequest{OrderId: "1", Amount: 100}
 
-    resp, err := s.CreatePayment(context.Background(), req)
-    if err != nil {
-        t.Fatalf("CreatePayment returned error: %v", err)
-    }
-    if resp.PaymentId != "demo" {
-        t.Errorf("expected payment_id 'demo', got %q", resp.PaymentId)
-    }
-    if resp.Status != "created" {
-        t.Errorf("expected status 'created', got %q", resp.Status)
-    }
+	resp, err := s.CreatePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreatePayment returned error: %v", err)
+	}
+	if resp.PaymentId != "1" {
+		t.Errorf("expected payment_id '1', got %q", resp.PaymentId)
+	}
+	if resp.Status != "PAID" {
+		t.Errorf("expected status 'PAID', got %q", resp.Status)
+	}
 }


### PR DESCRIPTION
## Summary
- add MIT license for open source terms
- reference license in README
- fix Payment service tests so go suite runs cleanly

## Testing
- `for proj in services/*/*.Tests/*.csproj; do dotnet test "$proj"; done`
- `(cd services/Payment && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_684a49955e04832ea31e8a42e1589574