### PR TITLE
Add Docker container for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@ npm run dev
 ```
 
 Set `VITE_API_BASE_URL` in `.env` to the gateway URL (default `http://localhost`).
+
+### Docker
+
+To run the frontend together with the microservices:
+
+```bash
+cd services
+docker compose up --build frontend
+```
+
+The UI will be available at `http://localhost:3000`.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -149,5 +149,18 @@ services:
       - "80:8000"
       - "8001:8001"
 
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: http://gateway:8000
+    image: frontend.app:dev
+    container_name: frontend
+    depends_on:
+      - gateway
+    ports:
+      - "3000:80"
+
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- add Dockerfile for building frontend
- include frontend service in docker-compose
- document Docker usage in README

## Testing
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj --verbosity quiet`
- `dotnet test services/User/User.Tests/User.Tests.csproj --verbosity quiet`
- `(cd services/Payment && go test ./...)`

------
https://chatgpt.com/codex/tasks/task_e_684ba4991b08832eaa79c0b455a78a0d