### PR TITLE
Add standalone compose for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,23 @@ npm run dev
 ```
 
 Set `VITE_API_BASE_URL` in `.env` to the gateway URL (default `http://localhost`).
+
+### Docker
+
+To run the frontend together with the microservices:
+
+```bash
+cd services
+docker compose up --build frontend
+```
+
+The UI will be available at `http://localhost:3000`.
+
+To build and run the frontend alone for quick testing:
+
+```bash
+cd frontend
+docker compose up --build
+```
+
+The app will still expect a gateway running on `http://localhost:8000`.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,3 +21,13 @@ npm run dev
 ```
 
 Create a `.env` file and set `VITE_API_BASE_URL` to the URL of the gateway (e.g. `http://localhost`).
+
+## Docker
+
+Run the built app in a container for standalone testing:
+
+```bash
+docker compose up --build
+```
+
+By default the build points to a gateway at `http://localhost:8000`.

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: http://localhost:8000
+    image: frontend.app:dev
+    container_name: frontend
+    ports:
+      - "3000:80"
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/node": "^20.10.6",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -19,7 +19,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -149,5 +149,18 @@ services:
       - "80:8000"
       - "8001:8001"
 
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: http://gateway:8000
+    image: frontend.app:dev
+    container_name: frontend
+    depends_on:
+      - gateway
+    ports:
+      - "3000:80"
+
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- provide a minimal docker-compose.yml in the `frontend` directory
- document how to run the frontend container by itself

## Testing
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj --verbosity quiet`
- `dotnet test services/User/User.Tests/User.Tests.csproj --verbosity quiet`
- `(cd services/Payment && go test ./...)`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684ba4991b08832eaa79c0b455a78a0d