### PR TITLE
Add standalone frontend compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ docker compose up --build frontend
 ```
 
 The UI will be available at `http://localhost:3000`.
+
+### Standalone Testing
+
+Run only the frontend in a container for quick UI testing:
+
+```bash
+cd frontend
+docker compose up --build
+```
+
+Change `VITE_API_BASE_URL` in `frontend/docker-compose.yml` if your gateway runs on a different host.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,3 +21,13 @@ npm run dev
 ```
 
 Create a `.env` file and set `VITE_API_BASE_URL` to the URL of the gateway (e.g. `http://localhost`).
+
+### Docker
+
+Build and run the UI in a container for standalone testing:
+
+```bash
+docker compose up --build
+```
+
+The site will be served on [http://localhost:3000](http://localhost:3000). Adjust `VITE_API_BASE_URL` in `docker-compose.yml` if necessary.

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Change this to your gateway URL when running together with backend
+        VITE_API_BASE_URL: http://localhost
+    image: frontend.app:dev
+    container_name: frontend
+    ports:
+      - "3000:80"


### PR DESCRIPTION
## Summary
- allow standalone testing of React web UI with new `frontend/docker-compose.yml`
- document how to run the frontend container individually

## Testing
- `dotnet test` *(fails: command not found)*
- `go test ./...` in `services/Payment` *(no test files)*

------
https://chatgpt.com/codex/tasks/task_e_684bdcaa7b24832ea1d6d7893f603d36