### PR TITLE
Install devDependencies in frontend build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package.json ./
-RUN npm install
+# Install both dependencies and devDependencies even though the base image sets
+# NODE_ENV=production. The build step requires @types/node for the Vite config
+# and other TypeScript tooling.
+RUN npm install --omit=dev=false
 COPY . .
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,4 +30,7 @@ Build and run the UI in a container for standalone testing:
 docker compose up --build
 ```
 
+The Dockerfile installs both dependencies and devDependencies so that
+TypeScript tooling has access to packages like `@types/node` during the build.
+
 The site will be served on [http://localhost:3000](http://localhost:3000). Adjust `VITE_API_BASE_URL` in `docker-compose.yml` if necessary.

--- a/services/Analytics/app/db.py
+++ b/services/Analytics/app/db.py
@@ -3,14 +3,13 @@ from sqlalchemy.orm import declarative_base
 import os
 from dotenv import load_dotenv
 
-# 加载.env里的变量
+# Load environment variables from a .env file if present
 load_dotenv()
 
-# 读取数据库连接串（一定要和.env里的变量名一致！）
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-# 调试用，确保读取到了
-print("DATABASE_URL =", DATABASE_URL)
+# Prefer the service-specific variable name used in docs and tests.
+DATABASE_URL = os.getenv("ConnectionStrings__AnalyticsDb") or os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL is not configured")
 
 engine = create_async_engine(DATABASE_URL, echo=False)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)


### PR DESCRIPTION
## Summary
- ensure devDependencies are installed when building the frontend image
- document this requirement in the frontend README
- fix analytics DB configuration so tests can run

## Testing
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj`
- `dotnet test services/User/User.Tests/User.Tests.csproj`
- `go test ./...` in `services/Payment`
- `poetry run pytest` in `services/Analytics`
- `docker-compose -f services/docker-compose.yml build` *(fails: Docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684bea0dafa0832eaada6666bae9842c