### PR TITLE
Fix analytics DSN, update tests

### DIFF
--- a/services/Analytics/tests/test_api.py
+++ b/services/Analytics/tests/test_api.py
@@ -1,10 +1,13 @@
 import asyncio
 import os
+import sys
+from pathlib import Path
 import pytest
 import pytest_asyncio
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 os.environ.setdefault("ConnectionStrings__AnalyticsDb", "sqlite+aiosqlite:///:memory:")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app.main import app, init_db
 
 @pytest_asyncio.fixture(autouse=True, scope="session")
@@ -13,14 +16,16 @@ async def setup_db():
 
 @pytest.mark.asyncio
 async def test_create_event():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.post("/events", json={"event_type": "view", "payload": {"id": 1}})
         assert resp.status_code == 200
         assert resp.json()["status"] == "received"
 
 @pytest.mark.asyncio
 async def test_get_metrics():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/metrics")
         assert resp.status_code == 200
         assert isinstance(resp.json(), dict)

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -99,7 +99,8 @@ services:
       - pg
     restart: unless-stopped
     environment:
-      ConnectionStrings__AnalyticsDb: "postgresql://catalog_admin:P@ssw0rd!@pg:5432/catalog"
+      # Use asyncpg for SQLAlchemy's async engine
+      ConnectionStrings__AnalyticsDb: "postgresql+asyncpg://catalog_admin:P@ssw0rd!@pg:5432/catalog"
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
## Summary
- use asyncpg DSN for analytics service
- update analytics tests for httpx 0.27 interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bf4ff26a8832ebeeeabbc72918bdd