### PR TITLE
Fix frontend base URL and enable CORS

### DIFF
--- a/services/Gateway/kong.yml
+++ b/services/Gateway/kong.yml
@@ -67,6 +67,13 @@ services:
         strip_path: true
 
 plugins:
+  - name: cors
+    config:
+      origins: ["*"]
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+      headers: ["*"]
+      exposed_headers: ["*"]
+      credentials: true
   - name: key-auth
   - name: acl
     config:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       context: ../frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: http://gateway:8000
+        VITE_API_BASE_URL: http://localhost
     image: frontend.app:dev
     container_name: frontend
     depends_on:


### PR DESCRIPTION
## Summary
- fix `VITE_API_BASE_URL` in the docker compose file so browser code can reach the gateway
- enable a global CORS plugin in `kong.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c3d0525e4832e9e72b9c2639f8ff3