### PR TITLE
Add API key support to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ npm run dev
 ```
 
 Set `VITE_API_BASE_URL` in `.env` to the gateway URL (default `http://localhost`).
+If Kong's `key-auth` plugin is enabled, also set `VITE_API_KEY` to a valid key so frontend requests are accepted.
 
 ### Docker
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,9 @@ COPY package.json ./
 RUN npm install --omit=dev=false
 COPY . .
 ARG VITE_API_BASE_URL
+ARG VITE_API_KEY
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_API_KEY=$VITE_API_KEY
 RUN npm run build
 
 FROM nginx:1.27-alpine

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,7 @@ npm run dev
 ```
 
 Create a `.env` file and set `VITE_API_BASE_URL` to the URL of the gateway (e.g. `http://localhost`).
+If the gateway has the `key-auth` plugin enabled, also provide `VITE_API_KEY` with your API key so the frontend can authenticate its requests.
 
 ### Docker
 

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       args:
         # Change this to your gateway URL when running together with backend
         VITE_API_BASE_URL: http://localhost
+        VITE_API_KEY: ""
     image: frontend.app:dev
     container_name: frontend
     ports:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2,7 +2,10 @@ import axios from 'axios'
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
-  headers: { 'Content-Type': 'application/json' },
+  headers: {
+    'Content-Type': 'application/json',
+    apikey: import.meta.env.VITE_API_KEY ?? '',
+  },
 })
 
 export default api

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -155,6 +155,7 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_API_BASE_URL: http://localhost
+        VITE_API_KEY: ""
     image: frontend.app:dev
     container_name: frontend
     depends_on:


### PR DESCRIPTION
## Summary
- include `apikey` header in Axios client
- document new `VITE_API_KEY` env var in READMEs
- pass API key build arg in Docker configurations

## Testing
- `dotnet test services/User/User.Tests/User.Tests.csproj`
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj`
- `go test ./...` in `services/Payment`


------
https://chatgpt.com/codex/tasks/task_e_68512f053308832ea0340e9652bd5952