### PR TITLE
Add Kong API key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ npm run dev
 ```
 
 Set `VITE_API_BASE_URL` in `.env` to the gateway URL (default `http://localhost`).
-If Kong's `key-auth` plugin is enabled, also set `VITE_API_KEY` to a valid key so frontend requests are accepted.
+If Kong's `key-auth` plugin is enabled, generate a key as shown in [docs/authentication.md](docs/authentication.md) and set `VITE_API_KEY=<your-key>`.
+Requests from the frontend will otherwise receive **401** or **403** errors.
 
 ### Docker
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,23 @@
+# Kong API Key Authentication
+
+This project secures the gateway using Kong's `key-auth` plugin. Follow these steps to create a consumer and generate a key for the frontend:
+
+1. Ensure the gateway is running. From the `services` directory:
+   ```bash
+   docker compose up --build gateway
+   ```
+2. Create a consumer named `frontend`:
+   ```bash
+   curl -X POST http://localhost:8001/consumers -d username=frontend
+   ```
+3. Generate an API key for that consumer:
+   ```bash
+   curl -X POST http://localhost:8001/consumers/frontend/key-auth
+   ```
+   The response includes a JSON payload containing a `key` field.
+4. Copy the value of `key` and set it as `VITE_API_KEY` in your environment or `.env` file:
+   ```bash
+   VITE_API_KEY=<your-key>
+   ```
+
+If the frontend is started without a valid key, requests through the gateway will result in **401 Unauthorized** or **403 Forbidden** errors.

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         # Change this to your gateway URL when running together with backend
         VITE_API_BASE_URL: http://localhost
-        VITE_API_KEY: ""
+        VITE_API_KEY: <your-key>
     image: frontend.app:dev
     container_name: frontend
     ports:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_API_BASE_URL: http://localhost
-        VITE_API_KEY: ""
+        VITE_API_KEY: <your-key>
     image: frontend.app:dev
     container_name: frontend
     depends_on:


### PR DESCRIPTION
## Summary
- document how to create a Kong consumer and API key
- mention 401/403 errors without a key
- reference new docs in README
- show API key placeholder in compose examples

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685229bab810832eb28bbf590f577d85