### PR TITLE
Update frontend env example URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ npm run dev
 ```
 
 Set `VITE_API_BASE_URL` in `.env` to the gateway URL (default `http://localhost`).
+The compose file exposes the gateway on port 80. If you run the gateway on its
+own it listens on port 8000 instead, so adjust the value accordingly.
 If Kong's `key-auth` plugin is enabled, also set `VITE_API_KEY` to a valid key so frontend requests are accepted.
 
 ### Docker

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=http://localhost

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,7 @@ npm run dev
 ```
 
 Create a `.env` file and set `VITE_API_BASE_URL` to the URL of the gateway (e.g. `http://localhost`).
+The docker compose configuration maps the gateway to port 80. When running the gateway by itself, it defaults to port 8000 so update the URL as needed.
 If the gateway has the `key-auth` plugin enabled, also provide `VITE_API_KEY` with your API key so the frontend can authenticate its requests.
 
 ### Docker


### PR DESCRIPTION
## Summary
- use gateway port 80 in `.env.example`
- explain the port difference when running the gateway alone

## Testing
- `dotnet test` *(fails: command not found)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685229bab81c832ea9109421ff745977