### PR TITLE
Fix gateway base URL for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ npm install
 npm run dev
 ```
 
-Set `VITE_API_BASE_URL` in `.env` to the gateway URL (default `http://localhost`).
+Set `VITE_API_BASE_URL` in `.env` to the gateway URL. Use `http://localhost` for
+local development, or `http://gateway:8000` when running inside Docker Compose.
 
 ### Docker
 
@@ -77,4 +78,5 @@ cd frontend
 docker compose up --build
 ```
 
-Change `VITE_API_BASE_URL` in `frontend/docker-compose.yml` if your gateway runs on a different host.
+Change `VITE_API_BASE_URL` in `frontend/docker-compose.yml` if your gateway runs
+on a different host, for example `http://gateway:8000` when using the compose network.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,8 +20,8 @@ npm install
 npm run dev
 ```
 
-Create a `.env` file and set `VITE_API_BASE_URL` to the URL of the gateway (e.g. `http://localhost`).
-The docker compose configuration maps the gateway to port 80. When running the gateway by itself, it defaults to port 8000 so update the URL as needed.
+Create a `.env` file and set `VITE_API_BASE_URL` to the gateway URL (use `http://localhost` for local development).
+When the frontend runs inside Docker Compose, point it to `http://gateway:8000` so requests reach the gateway container.
 If the gateway has the `key-auth` plugin enabled, also provide `VITE_API_KEY` with your API key so the frontend can authenticate its requests.
 
 ### Docker
@@ -35,4 +35,4 @@ docker compose up --build
 The Dockerfile installs both dependencies and devDependencies so that
 TypeScript tooling has access to packages like `@types/node` during the build.
 
-The site will be served on [http://localhost:3000](http://localhost:3000). Adjust `VITE_API_BASE_URL` in `docker-compose.yml` if necessary.
+The site will be served on [http://localhost:3000](http://localhost:3000). Adjust `VITE_API_BASE_URL` in `docker-compose.yml` if necessary (e.g. `http://gateway:8000`).

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
       args:
         # Change this to your gateway URL when running together with backend
-        VITE_API_BASE_URL: http://localhost
+        VITE_API_BASE_URL: http://gateway:8000
         VITE_API_KEY: <your-key>
     image: frontend.app:dev
     container_name: frontend

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       context: ../frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: http://localhost
+        VITE_API_BASE_URL: http://gateway:8000
         VITE_API_KEY: <your-key>
     image: frontend.app:dev
     container_name: frontend


### PR DESCRIPTION
## Summary
- update service and frontend compose files to send API requests to `http://gateway:8000`
- clarify README instructions for container use

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68526808d5b0832e9bca6dd848d0282e