### PR TITLE
Fix frontend forms and Analytics tests

### DIFF
--- a/frontend/src/pages/AddOrder.tsx
+++ b/frontend/src/pages/AddOrder.tsx
@@ -3,18 +3,17 @@ import { Container, TextField, Button, Typography } from '@mui/material'
 import api from '../api/api'
 
 export default function AddOrder() {
-  const [userId, setUserId] = useState('')
-  const [total, setTotal] = useState('')
+  const [productName, setProductName] = useState('')
+  const [price, setPrice] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       await api.post('/api/v1/order/orders', {
-        userId,
-        total: parseFloat(total),
+        items: [{ productName, price: parseFloat(price) }],
       })
-      setUserId('')
-      setTotal('')
+      setProductName('')
+      setPrice('')
       alert('Order created!')
     } catch (err) {
       console.error(err)
@@ -26,8 +25,8 @@ export default function AddOrder() {
     <Container>
       <Typography variant="h4" gutterBottom>Add Order</Typography>
       <form onSubmit={handleSubmit}>
-        <TextField label="User ID" fullWidth margin="normal" value={userId} onChange={e => setUserId(e.target.value)} />
-        <TextField label="Total" fullWidth margin="normal" value={total} onChange={e => setTotal(e.target.value)} />
+        <TextField label="Product Name" fullWidth margin="normal" value={productName} onChange={e => setProductName(e.target.value)} />
+        <TextField label="Price" fullWidth margin="normal" value={price} onChange={e => setPrice(e.target.value)} />
         <Button variant="contained" type="submit">Add</Button>
       </form>
     </Container>

--- a/frontend/src/pages/AddPayment.tsx
+++ b/frontend/src/pages/AddPayment.tsx
@@ -3,12 +3,17 @@ import { Container, TextField, Button, Typography } from '@mui/material'
 import api from '../api/api'
 
 export default function AddPayment() {
+  const [orderId, setOrderId] = useState('')
   const [amount, setAmount] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      await api.post('/api/v1/payment/v1/payment', { amount: parseFloat(amount) })
+      await api.post('/api/v1/payment/v1/payment', {
+        order_id: orderId,
+        amount: parseFloat(amount),
+      })
+      setOrderId('')
       setAmount('')
       alert('Payment sent!')
     } catch (err) {
@@ -21,6 +26,7 @@ export default function AddPayment() {
     <Container>
       <Typography variant="h4" gutterBottom>Send Payment</Typography>
       <form onSubmit={handleSubmit}>
+        <TextField label="Order ID" fullWidth margin="normal" value={orderId} onChange={e => setOrderId(e.target.value)} />
         <TextField label="Amount" fullWidth margin="normal" value={amount} onChange={e => setAmount(e.target.value)} />
         <Button variant="contained" type="submit">Send</Button>
       </form>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,17 +3,19 @@ import { Container, TextField, Button, Typography } from '@mui/material'
 import api from '../api/api'
 
 export default function Login() {
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       const params = new URLSearchParams()
-      params.append('grant_type', 'password')
-      params.append('username', username)
-      params.append('password', password)
+      params.append('grant_type', 'client_credentials')
+      params.append('client_id', clientId)
+      params.append('client_secret', clientSecret)
       await api.post('/api/v1/auth/connect/token', params)
+      setClientId('')
+      setClientSecret('')
       alert('Logged in!')
     } catch (err) {
       console.error(err)
@@ -25,8 +27,8 @@ export default function Login() {
     <Container>
       <Typography variant="h4" gutterBottom>Login</Typography>
       <form onSubmit={handleSubmit}>
-        <TextField label="Username" fullWidth margin="normal" value={username} onChange={e => setUsername(e.target.value)} />
-        <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={e => setPassword(e.target.value)} />
+        <TextField label="Client ID" fullWidth margin="normal" value={clientId} onChange={e => setClientId(e.target.value)} />
+        <TextField label="Client Secret" type="password" fullWidth margin="normal" value={clientSecret} onChange={e => setClientSecret(e.target.value)} />
         <Button variant="contained" type="submit">Login</Button>
       </form>
     </Container>

--- a/frontend/src/pages/OrderList.tsx
+++ b/frontend/src/pages/OrderList.tsx
@@ -2,10 +2,16 @@ import { useEffect, useState } from 'react'
 import { Container, Typography, Card, CardContent } from '@mui/material'
 import api from '../api/api'
 
+interface OrderItem {
+  productName: string
+  price: number
+}
+
 interface Order {
   id: string
-  userId: string
-  total: number
+  items: OrderItem[]
+  totalPrice: number
+  status: string
 }
 
 export default function OrderList() {
@@ -24,8 +30,11 @@ export default function OrderList() {
         <Card key={o.id} sx={{ mb: 2 }}>
           <CardContent>
             <Typography variant="h6">Order #{o.id}</Typography>
-            <Typography>User {o.userId}</Typography>
-            <Typography>${o.total}</Typography>
+            <Typography>Status: {o.status}</Typography>
+            <Typography>Total: ${o.totalPrice}</Typography>
+            {o.items.map((item, idx) => (
+              <Typography key={idx}>- {item.productName}: ${item.price}</Typography>
+            ))}
           </CardContent>
         </Card>
       ))}

--- a/frontend/src/pages/RiskCheck.tsx
+++ b/frontend/src/pages/RiskCheck.tsx
@@ -3,14 +3,16 @@ import { Container, TextField, Button, Typography } from '@mui/material'
 import api from '../api/api'
 
 export default function RiskCheck() {
-  const [orderId, setOrderId] = useState('')
+  const [userId, setUserId] = useState('')
+  const [action, setAction] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      await api.post('/api/v1/security/risk/order-check', { orderId })
+      await api.post('/api/v1/security/risk/order-check', { userId, action })
       alert('Risk check sent!')
-      setOrderId('')
+      setUserId('')
+      setAction('')
     } catch (err) {
       console.error(err)
       alert('Failed to check risk')
@@ -21,7 +23,8 @@ export default function RiskCheck() {
     <Container>
       <Typography variant="h4" gutterBottom>Order Risk Check</Typography>
       <form onSubmit={handleSubmit}>
-        <TextField label="Order ID" fullWidth margin="normal" value={orderId} onChange={e => setOrderId(e.target.value)} />
+        <TextField label="User ID" fullWidth margin="normal" value={userId} onChange={e => setUserId(e.target.value)} />
+        <TextField label="Action" fullWidth margin="normal" value={action} onChange={e => setAction(e.target.value)} />
         <Button variant="contained" type="submit">Check</Button>
       </form>
     </Container>

--- a/services/Analytics/tests/test_api.py
+++ b/services/Analytics/tests/test_api.py
@@ -2,9 +2,10 @@ import asyncio
 import os
 import pytest
 import pytest_asyncio
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
-os.environ.setdefault("ConnectionStrings__AnalyticsDb", "sqlite+aiosqlite:///:memory:")
+# Ensure the app uses an in-memory database during tests
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 from app.main import app, init_db
 
 @pytest_asyncio.fixture(autouse=True, scope="session")
@@ -13,14 +14,16 @@ async def setup_db():
 
 @pytest.mark.asyncio
 async def test_create_event():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.post("/events", json={"event_type": "view", "payload": {"id": 1}})
         assert resp.status_code == 200
         assert resp.json()["status"] == "received"
 
 @pytest.mark.asyncio
 async def test_get_metrics():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/metrics")
         assert resp.status_code == 200
         assert isinstance(resp.json(), dict)


### PR DESCRIPTION
## Summary
- align AddOrder request with item schema
- include order_id with AddPayment
- use client credentials login
- display new order details and status
- send userId/action in RiskCheck
- fix Analytics tests for httpx

## Testing
- `for proj in services/*/*.Tests/*.csproj; do dotnet test "$proj"; done`
- `cd services/Payment && go test ./...`
- `cd services/Analytics && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b1f9523c832ea6d83abc294c7d25