### PR TITLE
Ensure DB setup automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ From the `services` directory you can spin up the entire stack:
 docker compose up --build
 ```
 
+Before starting the stack, apply the Entity Framework migrations for each .NET service:
+```bash
+cd services/Catalog && dotnet ef database update
+cd ../Order && dotnet ef database update
+cd ../User && dotnet ef database update
+cd ../Auth && dotnet ef database update
+cd ..
+```
+
 Run a single service for local testing using its Docker Compose file:
 
 ```bash

--- a/services/Auth/Program.cs
+++ b/services/Auth/Program.cs
@@ -37,6 +37,13 @@ builder.Services.AddIdentityServer()
 
 var app = builder.Build();
 
+// Ensure database exists
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.UseIdentityServer();
 
 app.MapGet("/", () => "Auth Service running");

--- a/services/Catalog/Program.cs
+++ b/services/Catalog/Program.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.EntityFrameworkCore;
-using Catalog.Api.Infrastructure; // ÄãµÄ DbContext ËùÔÚÃüÃû¿Õ¼ä
+using Catalog.Api.Infrastructure; // ä½ çš„ DbContext æ‰€åœ¨å‘½åç©ºé—´
 using System;
 using System.Threading.Tasks;
 using System.Collections.Immutable;
@@ -14,15 +14,22 @@ using Microsoft.AspNetCore.Hosting;
 using Swashbuckle.AspNetCore.Annotations;
 using Microsoft.Extensions.Configuration;
 
-// ÆäËû using ...
+// å…¶ä»– using ...
 
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Ç¿ÖÆ¼àÌı 0.0.0.0:80 ¶Ë¿Ú£¬ÊÊÅä Docker
+// Apply pending EF Core migrations automatically
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<CatalogDbContext>();
+    db.Database.Migrate();
+}
+
+// å¼ºåˆ¶ç›‘å¬ 0.0.0.0:80 ç«¯å£ï¼Œé€‚é… Docker
 builder.WebHost.UseUrls("http://0.0.0.0:80");
 
-// ...ÒÔÏÂ±£³Ö²»±ä
+// ...ä»¥ä¸‹ä¿æŒä¸å˜
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(o =>

--- a/services/Order/Program.cs
+++ b/services/Order/Program.cs
@@ -48,6 +48,13 @@ builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete
 
 var app = builder.Build();
 
+// Ensure database exists
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<OrderDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.UseSwagger();
 app.UseSwaggerUI();
 app.MapControllers();

--- a/services/Shipping/Program.cs
+++ b/services/Shipping/Program.cs
@@ -2,9 +2,9 @@ using Microsoft.EntityFrameworkCore;
 using Shipping.Api.Infrastructure;
 using MassTransit;
 using Hangfire;
-// ¡ï ĞÂÔöĞĞ£ºÒıÈëÄÚ´æ´æ´¢°ü
-using Hangfire.MemoryStorage;                     // <-- ĞŞ¸Ä
-// using Hangfire.PostgreSql;                    // ¡û ÕâÒ»ĞĞ¿ÉÒÔÉ¾µô»ò×¢ÊÍ
+// â˜… æ–°å¢è¡Œï¼šå¼•å…¥å†…å­˜å­˜å‚¨åŒ…
+using Hangfire.MemoryStorage;                     // <-- ä¿®æ”¹
+// using Hangfire.PostgreSql;                    // â† è¿™ä¸€è¡Œå¯ä»¥åˆ æ‰æˆ–æ³¨é‡Š
 using Shipping.Api.Jobs;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -18,16 +18,23 @@ builder.Services.AddSwaggerGen(o =>
     o.SwaggerDoc("v1", new() { Title = "Shipping API", Version = "v1" });
 });
 
-// ¡ï ¸Ä³É In-Memory DB
+// Ensure database exists
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ShippingDbContext>();
+    db.Database.EnsureCreated();
+}
+
+// â˜… æ”¹æˆ In-Memory DB
 builder.Services.AddDbContext<ShippingDbContext>(options =>
 {
-    options.UseInMemoryDatabase("ShippingTest");  // <-- ĞŞ¸Ä
+    options.UseInMemoryDatabase("ShippingTest");  // <-- ä¿®æ”¹
 });
 
-// ¡ï Hangfire Ò²»»³ÉÄÚ´æ´æ´¢
+// â˜… Hangfire ä¹Ÿæ¢æˆå†…å­˜å­˜å‚¨
 builder.Services.AddHangfire(config =>
 {
-    config.UseMemoryStorage();                    // <-- ĞŞ¸Ä
+    config.UseMemoryStorage();                    // <-- ä¿®æ”¹
 });
 builder.Services.AddHangfireServer();
 
@@ -47,7 +54,7 @@ app.UseRouting();
 app.UseHangfireDashboard();
 app.MapControllers();
 
-// ¡ï ¶¨Ê±ÈÎÎñÕÕ³£¿ÉÓÃ
+// â˜… å®šæ—¶ä»»åŠ¡ç…§å¸¸å¯ç”¨
 RecurringJob.AddOrUpdate<CheckPendingShipmentsJob>(
     "check-pending",
     job => job.Run(),

--- a/services/User/Program.cs
+++ b/services/User/Program.cs
@@ -44,6 +44,13 @@ builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete
 
 var app = builder.Build();
 
+// Ensure database exists
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<UserDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.UseSwagger();
 app.UseSwaggerUI();
 app.MapControllers();


### PR DESCRIPTION
## Summary
- autoprovision databases for .NET services at startup
- document running migrations prior to compose up

## Testing
- `go test ./...` in `services/Payment`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f4629ae4832e9aa1a97d0e044483