### PR TITLE
Fix frontend gateway URL in compose file

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -160,7 +160,7 @@ services:
       context: ../frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: http://localhost:8000
+        VITE_API_BASE_URL: http://gateway:8000
         VITE_API_KEY: mytestkey123
     image: frontend.app:dev
     container_name: frontend


### PR DESCRIPTION
## Summary
- point VITE_API_BASE_URL to gateway service so frontend can reach backend when running docker compose

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bcd907e0c832eb0ad625dac273628