### PR TITLE
Fix gateway URL and SPA routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ npm install
 npm run dev
 ```
 
-Set `VITE_API_BASE_URL` in `.env` to the gateway URL. Use `http://localhost` for
-local development, or `http://gateway:8000` when running inside Docker Compose.
+Set `VITE_API_BASE_URL` in `.env` to the gateway URL. When the frontend is
+served to your browser it runs outside Docker, so it should access the gateway
+through the host at `http://localhost:8000`.
 
 ### Docker
 
@@ -68,6 +69,8 @@ docker compose up --build frontend
 ```
 
 The UI will be available at `http://localhost:3000`.
+The container includes a small nginx configuration so that refreshing browser
+routes like `/add-user` loads the SPA's `index.html` rather than returning a 404.
 
 ### Standalone Testing
 
@@ -78,8 +81,9 @@ cd frontend
 docker compose up --build
 ```
 
-Change `VITE_API_BASE_URL` in `frontend/docker-compose.yml` if your gateway runs
-on a different host, for example `http://gateway:8000` when using the compose network.
+Change `VITE_API_BASE_URL` in `frontend/docker-compose.yml` to match the gateway
+address (for example `http://gateway:8000` when both containers are on the same
+Docker network).
 
 When the frontend container is run on its own or the gateway is not in the same Docker network, pass the actual gateway address during the build step:
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,5 +14,7 @@ RUN npm run build
 
 FROM nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+# Provide an nginx config that routes all paths to index.html for SPA routing
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -160,6 +160,7 @@ services:
       context: ../frontend
       dockerfile: Dockerfile
       args:
+        # Use localhost so the browser outside Docker can reach the gateway
         VITE_API_BASE_URL: http://localhost:8000
         VITE_API_KEY: mytestkey123
     image: frontend.app:dev


### PR DESCRIPTION
## Summary
- correct VITE_API_BASE_URL in docker-compose
- add nginx config so direct routes work in frontend container
- document using localhost for gateway access

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bcd907e0c832eb0ad625dac273628