### PR TITLE
Fix frontend gateway URL instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ npm run dev
 ```
 
 Set `VITE_API_BASE_URL` in `.env` to the gateway URL. Use `http://localhost` for
-local development, or `http://gateway:8000` when running inside Docker Compose.
+local development. When the site is served to your host browser from Docker
+Compose, the gateway is still reached through `localhost:8000` rather than the
+`gateway` container name.
 
 ### Docker
 
@@ -79,7 +81,9 @@ docker compose up --build
 ```
 
 Change `VITE_API_BASE_URL` in `frontend/docker-compose.yml` if your gateway runs
-on a different host, for example `http://gateway:8000` when using the compose network.
+on a different host. Use the host address such as `http://localhost:8000` when
+you access the UI from your browser. The `gateway` hostname is only resolvable
+from within the Docker network.
 
 When the frontend container is run on its own or the gateway is not in the same Docker network, pass the actual gateway address during the build step:
 

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       dockerfile: Dockerfile
       args:
         # Change this to your gateway URL when running together with backend
-        VITE_API_BASE_URL: http://gateway:8000
+        # Use http://localhost:8000 when opening the site from your host browser
+        VITE_API_BASE_URL: http://localhost:8000
         VITE_API_KEY: <your-key>
     image: frontend.app:dev
     container_name: frontend

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -160,7 +160,8 @@ services:
       context: ../frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: http://gateway:8000
+        # Use the host URL so browser requests resolve correctly
+        VITE_API_BASE_URL: http://localhost:8000
         VITE_API_KEY: mytestkey123
     image: frontend.app:dev
     container_name: frontend


### PR DESCRIPTION
## Summary
- clarify gateway URL in README for browser access
- default to localhost gateway in frontend docker-compose
- update compose stack to use localhost for frontend build

## Testing
- `dotnet test` *(fails: `command not found`)*
- `go test ./...` in `services/Payment`

------
https://chatgpt.com/codex/tasks/task_e_685bf8693fd0832e974eb17abe14cb22