### PR TITLE
Fix Nginx SPA handling and user DB init

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,5 +14,6 @@ RUN npm run build
 
 FROM nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,3 +36,6 @@ The Dockerfile installs both dependencies and devDependencies so that
 TypeScript tooling has access to packages like `@types/node` during the build.
 
 The site will be served on [http://localhost:3000](http://localhost:3000). Adjust `VITE_API_BASE_URL` in `docker-compose.yml` if necessary (e.g. `http://gateway:8000`).
+
+Unknown paths are rewritten to `index.html` via the bundled `nginx.conf`,
+allowing browser refreshes on routes like `/add-user` without returning 404.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,19 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+
+    server {
+        listen 80;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/services/User/Program.cs
+++ b/services/User/Program.cs
@@ -44,6 +44,13 @@ builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete
 
 var app = builder.Build();
 
+// Ensure the user schema exists at startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<UserDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.UseSwagger();
 app.UseSwaggerUI();
 app.MapControllers();

--- a/services/User/README.md
+++ b/services/User/README.md
@@ -21,4 +21,8 @@ Then run with Docker Compose:
 docker compose up --build
 ```
 
+The service automatically creates its database schema on startup using
+`EnsureCreated()`. Make sure the configured PostgreSQL instance is reachable
+before running the container.
+
 See `Minimum.md` for integration details and `openapi.yaml` for the full API contract.


### PR DESCRIPTION
## Summary
- add Nginx config for SPA fallback and copy it in the Dockerfile
- clarify SPA refresh in frontend README
- auto-create the users table at startup
- document automatic DB creation in User service README

## Testing
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj`
- `dotnet test services/User/User.Tests/User.Tests.csproj`
- `go test ./...` in `services/Payment`


------
https://chatgpt.com/codex/tasks/task_e_685c046e9798832e940a4344f9bc48c6