### PR TITLE
Fix login content type and CORS

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -13,7 +13,9 @@ export default function Login() {
       params.append('grant_type', 'client_credentials')
       params.append('client_id', clientId)
       params.append('client_secret', clientSecret)
-      await api.post('/api/v1/auth/connect/token', params)
+      await api.post('/api/v1/auth/connect/token', params, {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      })
       setClientId('')
       setClientSecret('')
       alert('Logged in!')

--- a/services/Auth/Program.cs
+++ b/services/Auth/Program.cs
@@ -29,7 +29,8 @@ builder.Services.AddIdentityServer()
             ClientId = "sample",
             AllowedGrantTypes = GrantTypes.ClientCredentials,
             ClientSecrets = { new Secret("secret".Sha256()) },
-            AllowedScopes = { "api1" }
+            AllowedScopes = { "api1" },
+            AllowedCorsOrigins = { "http://localhost:3000" }
         }
     })
     .AddInMemoryApiScopes(new[] { new ApiScope("api1", "API") })


### PR DESCRIPTION
## Summary
- ensure login form uses `application/x-www-form-urlencoded`
- allow frontend origin in Auth service

## Testing
- `dotnet test` *(fails: command not found)*
- `cd services/Payment && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ceba5d8e0832e9afff64d83096c8e