### PR TITLE
Fix JSON cycles in Order API

### DIFF
--- a/services/Order/Domain/OrderItem.cs
+++ b/services/Order/Domain/OrderItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 
 namespace Order.Api.Domain;
 
@@ -8,5 +9,6 @@ public class OrderItem
     public Guid OrderId { get; set; }
     public string ProductName { get; set; } = default!;
     public decimal Price { get; set; }
+    [JsonIgnore]
     public OrderEntity? Order { get; set; }
 }

--- a/services/Order/Program.cs
+++ b/services/Order/Program.cs
@@ -21,7 +21,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.WebHost.UseUrls("http://0.0.0.0:80");
 
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
+});
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(o =>
 {


### PR DESCRIPTION
## Summary
- annotate `OrderItem.Order` with `[JsonIgnore]`
- configure `ReferenceHandler.IgnoreCycles` in JSON options

## Testing
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685d107ed6e8832e9b34458aed88f6e2