### PR TITLE
Fix login and README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,6 +12,12 @@ This React + Vite application provides a very small portal for both customers an
 - Analytics metrics view
 - Authentication and basic risk check
 
+### Login Form
+
+The **Login** page now supports both the `client_credentials` and `password` OAuth2 grant types.
+Choose the grant type from the dropdown and enter the required fields. When a sample client ID (`1` or `2`) is entered, the form automatically switches to the password grant.
+Use the provided test user (`user1`/`pass1`) with these clients.
+
 ## Development
 
 ```

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,23 +1,38 @@
-import { useState } from 'react'
-import { Container, TextField, Button, Typography } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { Container, TextField, Button, Typography, MenuItem } from '@mui/material'
 import api from '../api/api'
 
 export default function Login() {
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
+  const [grantType, setGrantType] = useState('client_credentials')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  useEffect(() => {
+    if (clientId === '1' || clientId === '2') {
+      setGrantType('password')
+    }
+  }, [clientId])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       const params = new URLSearchParams()
-      params.append('grant_type', 'client_credentials')
+      params.append('grant_type', grantType)
       params.append('client_id', clientId)
       params.append('client_secret', clientSecret)
+      if (grantType === 'password') {
+        params.append('username', username)
+        params.append('password', password)
+      }
       await api.post('/api/v1/auth/connect/token', params, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
       })
       setClientId('')
       setClientSecret('')
+      setUsername('')
+      setPassword('')
       alert('Logged in!')
     } catch (err) {
       console.error(err)
@@ -29,8 +44,18 @@ export default function Login() {
     <Container>
       <Typography variant="h4" gutterBottom>Login</Typography>
       <form onSubmit={handleSubmit}>
+        <TextField label="Grant Type" select fullWidth margin="normal" value={grantType} onChange={e => setGrantType(e.target.value)}>
+          <MenuItem value="client_credentials">client_credentials</MenuItem>
+          <MenuItem value="password">password</MenuItem>
+        </TextField>
         <TextField label="Client ID" fullWidth margin="normal" value={clientId} onChange={e => setClientId(e.target.value)} />
         <TextField label="Client Secret" type="password" fullWidth margin="normal" value={clientSecret} onChange={e => setClientSecret(e.target.value)} />
+        {grantType === 'password' && (
+          <>
+            <TextField label="Username" fullWidth margin="normal" value={username} onChange={e => setUsername(e.target.value)} />
+            <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={e => setPassword(e.target.value)} />
+          </>
+        )}
         <Button variant="contained" type="submit">Login</Button>
       </form>
     </Container>


### PR DESCRIPTION
## Summary
- automatically switch to password grant for sample clients
- document automatic grant selection in the frontend README

## Testing
- `go test ./services/Payment/...`
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6860bacf07cc832e93f29f2b82d4d930