### PR TITLE
Simplify password grant login

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,8 +15,10 @@ This React + Vite application provides a very small portal for both customers an
 ### Login Form
 
 The **Login** page now supports both the `client_credentials` and `password` OAuth2 grant types.
-Choose the grant type from the dropdown and enter the required fields. When a sample client ID (`1` or `2`) is entered, the form automatically switches to the password grant.
+Choose the grant type from the dropdown and enter the required fields.
+When the password grant is selected, the form only asks for a username and password. Sample client credentials (`1`/`secret1`) are filled in automatically.
 Use the provided test user (`user1`/`pass1`) with these clients.
+All requests include the `api1` scope which the Auth service requires to issue a token.
 
 ## Development
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,6 +15,15 @@ export default function Login() {
     }
   }, [clientId])
 
+  const handleGrantTypeChange = (value: string) => {
+    setGrantType(value)
+    if (value === 'password') {
+      // use sample client credentials automatically
+      setClientId('1')
+      setClientSecret('secret1')
+    }
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
@@ -22,6 +31,8 @@ export default function Login() {
       params.append('grant_type', grantType)
       params.append('client_id', clientId)
       params.append('client_secret', clientSecret)
+      // IdentityServer requires at least one scope when requesting a token
+      params.append('scope', 'api1')
       if (grantType === 'password') {
         params.append('username', username)
         params.append('password', password)
@@ -44,12 +55,16 @@ export default function Login() {
     <Container>
       <Typography variant="h4" gutterBottom>Login</Typography>
       <form onSubmit={handleSubmit}>
-        <TextField label="Grant Type" select fullWidth margin="normal" value={grantType} onChange={e => setGrantType(e.target.value)}>
+        <TextField label="Grant Type" select fullWidth margin="normal" value={grantType} onChange={e => handleGrantTypeChange(e.target.value)}>
           <MenuItem value="client_credentials">client_credentials</MenuItem>
           <MenuItem value="password">password</MenuItem>
         </TextField>
-        <TextField label="Client ID" fullWidth margin="normal" value={clientId} onChange={e => setClientId(e.target.value)} />
-        <TextField label="Client Secret" type="password" fullWidth margin="normal" value={clientSecret} onChange={e => setClientSecret(e.target.value)} />
+        {grantType === 'client_credentials' && (
+          <>
+            <TextField label="Client ID" fullWidth margin="normal" value={clientId} onChange={e => setClientId(e.target.value)} />
+            <TextField label="Client Secret" type="password" fullWidth margin="normal" value={clientSecret} onChange={e => setClientSecret(e.target.value)} />
+          </>
+        )}
         {grantType === 'password' && (
           <>
             <TextField label="Username" fullWidth margin="normal" value={username} onChange={e => setUsername(e.target.value)} />


### PR DESCRIPTION
## Summary
- adjust Login page to only require username and password for the password grant
- auto-fill sample credentials (`1`/`secret1`) when password grant is chosen
- update documentation about the simplified fields

## Testing
- `go test ./...` in Payment service
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610b348698832e8ae33867615d464a