### PR TITLE
Fix client_credentials docs

### DIFF
--- a/services/Auth/openapi.yaml
+++ b/services/Auth/openapi.yaml
@@ -29,6 +29,7 @@ paths:
                 - grant_type
                 - client_id
                 - client_secret
+                - scope
       responses:
         '200':
           description: Token response


### PR DESCRIPTION
## Summary
- require the `scope` field in the Auth service OpenAPI spec

## Testing
- `npm install` in `frontend`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68612f4fef58832ebdea85b14a9e9b2f