### PR TITLE
Add Catalog and Shipping tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Run tests
         run: |
-          for proj in services/*/*.Tests/*.csproj; do dotnet test "$proj" --no-build; done
+          for proj in services/*/*.Tests/*.csproj; do
+            echo "Testing $proj"
+            dotnet test "$proj" --no-build
+          done
           (cd services/Payment && go test ./...)
       - name: Build images
         run: docker compose -f services/docker-compose.yml build

--- a/services/Catalog/Catalog.Tests/Catalog.Tests.csproj
+++ b/services/Catalog/Catalog.Tests/Catalog.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Catalog.csproj" />
+  </ItemGroup>
+</Project>

--- a/services/Catalog/Catalog.Tests/GlobalUsings.cs
+++ b/services/Catalog/Catalog.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/services/Catalog/Catalog.Tests/ProductTests.cs
+++ b/services/Catalog/Catalog.Tests/ProductTests.cs
@@ -1,0 +1,17 @@
+using Catalog.Api.Domain;
+
+namespace Catalog.Tests;
+
+public class ProductTests
+{
+    [Fact]
+    public void Update_SetsProperties()
+    {
+        var product = new Product();
+        product.Update("Phone", "Smart device", 199m);
+
+        Assert.Equal("Phone", product.Name);
+        Assert.Equal("Smart device", product.Description);
+        Assert.Equal(199m, product.Price);
+    }
+}

--- a/services/Catalog/Catalog.Tests/ProductsControllerTests.cs
+++ b/services/Catalog/Catalog.Tests/ProductsControllerTests.cs
@@ -1,0 +1,27 @@
+using Catalog.Api.Contracts;
+using Catalog.Api.Controllers;
+using Catalog.Api.Infrastructure;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Catalog.Tests;
+
+public class ProductsControllerTests
+{
+    [Fact]
+    public async Task Create_AddsProduct()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDbContext>()
+            .UseInMemoryDatabase("catalog-test")
+            .Options;
+        await using var db = new CatalogDbContext(options);
+        var controller = new ProductsController(db);
+        var dto = new CreateProductDto("Item", "Desc", 9.99m);
+
+        var result = await controller.Create(dto);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        Assert.NotEqual(Guid.Empty, (Guid)created.Value!);
+        Assert.Single(db.Products);
+    }
+}

--- a/services/Catalog/Catalog.csproj
+++ b/services/Catalog/Catalog.csproj
@@ -14,6 +14,9 @@
 		</PackageReference>
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
-	</ItemGroup>
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
+        </ItemGroup>
+        <ItemGroup>
+                <Compile Remove="Catalog.Tests/**/*.cs" />
+        </ItemGroup>
 </Project>

--- a/services/Shipping/Shipping.Tests/GlobalUsings.cs
+++ b/services/Shipping/Shipping.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/services/Shipping/Shipping.Tests/ShipmentTests.cs
+++ b/services/Shipping/Shipping.Tests/ShipmentTests.cs
@@ -1,0 +1,14 @@
+using Shipping.Api.Domain;
+
+namespace Shipping.Tests;
+
+public class ShipmentTests
+{
+    [Fact]
+    public void NewShipment_HasDefaults()
+    {
+        var shipment = new Shipment { OrderId = "1" };
+        Assert.Equal("Created", shipment.Status);
+        Assert.True(shipment.CreatedAt <= DateTime.UtcNow);
+    }
+}

--- a/services/Shipping/Shipping.Tests/ShipmentsControllerTests.cs
+++ b/services/Shipping/Shipping.Tests/ShipmentsControllerTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using Shipping.Api.Controllers;
+
+namespace Shipping.Tests;
+
+public class ShipmentsControllerTests
+{
+    [Fact]
+    public void CalculateRate_ReturnsExpectedValue()
+    {
+        var controller = new ShipmentsController(null!, null!);
+        var result = controller.CalculateRate(new ShipmentsController.RateRequest(2m, "US"));
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(2m * 1.25m, ok.Value);
+    }
+}

--- a/services/Shipping/Shipping.Tests/Shipping.Tests.csproj
+++ b/services/Shipping/Shipping.Tests/Shipping.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Shipping.csproj" />
+  </ItemGroup>
+</Project>

--- a/services/Shipping/Shipping.csproj
+++ b/services/Shipping/Shipping.csproj
@@ -16,4 +16,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.36" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.8.4" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Shipping.Tests/**/*.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add new Catalog.Tests project covering domain and controller basics
- add new Shipping.Tests project verifying rate and entity defaults
- update Catalog and Shipping csproj files to exclude test files
- print project name during .NET tests in the CI workflow

## Testing
- `dotnet test services/Catalog/Catalog.Tests/Catalog.Tests.csproj`
- `dotnet test services/Shipping/Shipping.Tests/Shipping.Tests.csproj`
- `go test ./...` in `services/Payment`
- `poetry run pytest` *(fails: ModuleNotFoundError for pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_686a3350ae8c832eaea64e365c7345e8