### PR TITLE
Add Jest tests for ProductList

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,16 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Run tests
         run: |
           for proj in services/*/*.Tests/*.csproj; do dotnet test "$proj" --no-build; done
           (cd services/Payment && go test ./...)
+          (cd frontend && npm ci && npm test --ci --silent)
       - name: Build images
         run: docker compose -f services/docker-compose.yml build
       - name: Sync Kong config

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The `frontend` directory contains a Vite + React application that exposes basic 
 ```bash
 cd frontend
 npm install
+npm test
 npm run dev
 ```
 

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -28,6 +28,14 @@ done
 cd services/Payment && go test ./...
 ```
 
+Run frontend tests using Jest:
+
+```bash
+cd frontend
+npm install
+npm test
+```
+
 Bring up the stack locally with Docker:
 
 ```bash

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,15 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.jest.json',
+      useESM: false
+    }
+  },
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  transform: {}
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -29,6 +30,13 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "identity-obj-proxy": "^3.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"

--- a/frontend/src/api/__mocks__/api.ts
+++ b/frontend/src/api/__mocks__/api.ts
@@ -1,0 +1,4 @@
+const api = {
+  get: jest.fn()
+}
+export default api

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import ProductList from './ProductList'
+import api from '../api/api'
+
+jest.mock('../api/api')
+
+describe('ProductList', () => {
+  it('renders products from API', async () => {
+    const products = [
+      { id: '1', name: 'Test Product', description: 'Desc', price: 10 }
+    ]
+    ;(api.get as jest.Mock).mockResolvedValue({ data: products })
+
+    render(<ProductList />)
+
+    expect(api.get).toHaveBeenCalledWith('/api/v1/catalog/products')
+    expect(await screen.findByText('Test Product')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/tsconfig.jest.json
+++ b/frontend/tsconfig.jest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- configure Jest with React Testing Library
- add ProductList component unit test with API mock
- run frontend tests in CI workflow
- document how to run frontend tests

## Testing
- `dotnet test services/*/*.Tests/*.csproj --no-build` *(fails: command not found)*
- `(cd services/Payment && go test ./...)`
- `(cd frontend && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_e_686a335c905c832eb34fbb163281c893