### PR TITLE
Improve DB constraints and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,5 @@ docker compose -f docker-compose.tests.yml up --build --abort-on-container-exit
 
 Each container installs dependencies and runs the suite for its service. See [docs/testing.md](docs/testing.md) for more information.
 
+Database conventions and indexing tips are documented in [docs/database.md](docs/database.md).
+

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,33 @@
+# Database Guidelines
+
+This document collects conventions and tips for designing the service schemas.
+
+## Naming
+
+- Use **lowercase with underscores** for table and column names.
+- Keep each microservice in its own PostgreSQL schema to avoid collisions.
+
+## Constraints
+
+- Add unique indexes on business keys such as usernames or emails.
+- Reference related records with foreign keys when possible. If schemas are
+  separate, validate the relationship in the application layer.
+- Maintain integrity for order items and inventory updates either through
+  database constraints or transactional logic.
+
+## Indexes
+
+- Create indexes for common lookup fields. Examples:
+  - `users.user_name` and `users.email` for login.
+  - `orders(user_id, created_at)` to speed up history queries.
+  - `products(name)` and `products(category)` for catalog searches.
+- Revisit the query plan regularly as data grows and adjust indexes
+  accordingly.
+
+## Migrations
+
+Use `EF Core Migrations` or similar tools to evolve the schemas over time.
+Commit migration files alongside the code so that environments stay in sync.
+
+Maintaining these practices keeps the data model consistent across services and
+improves overall performance.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -62,3 +62,12 @@ cd services/Cart
 ./debug-cart.sh
 ```
 
+## Order Service
+
+Run the Order service in watch mode:
+
+```bash
+cd services/Order
+./debug-order.sh
+```
+

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -25,3 +25,6 @@ Grafana is available on [http://localhost:3001](http://localhost:3001) with the 
 ## Customising
 
 Edit `services/prometheus.yml` to add additional scrape targets for other services if they expose metrics endpoints.
+
+Alerting rules are defined in `services/prometheusRule.yaml`. Prometheus will trigger
+notifications when thresholds such as stalled orders or payment failures are exceeded.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,3 +18,21 @@ This spins up containers that install dependencies and run the test suites:
 - **frontend.tests** – installs Node modules and runs Jest
 
 Containers exit after finishing. Review their logs for results.
+
+## Local Runs
+
+You can also execute tests without Docker. Install dependencies with
+`poetry` and run `pytest` inside each service directory:
+
+```bash
+cd services/Analytics
+poetry install
+pytest
+
+cd ../Inventory
+poetry install
+pytest
+```
+
+When launching tests from the repository root, set `PYTHONPATH` to the
+service path so imports of the `app` package resolve correctly.

--- a/services/Catalog/Infrastructure/CatalogDbContext.cs
+++ b/services/Catalog/Infrastructure/CatalogDbContext.cs
@@ -23,12 +23,14 @@ public class CatalogDbContext(DbContextOptions<CatalogDbContext> options)
               .HasMaxLength(1000);
               eb.Property(p => p.Price)
                 .HasColumnType("numeric(12,2)");
-              eb.Property(p => p.ImageUrl)
+            eb.Property(p => p.ImageUrl)
                 .HasMaxLength(500);
-              eb.Property(p => p.Category)
+            eb.Property(p => p.Category)
                 .HasMaxLength(200)
                 .IsRequired();
-              eb.Property(p => p.Stock);
-          });
+            eb.Property(p => p.Stock);
+            eb.HasIndex(p => p.Name);
+            eb.HasIndex(p => p.Category);
+        });
       }
   }

--- a/services/Catalog/Migrations/20250726120200_AddIndexes.cs
+++ b/services/Catalog/Migrations/20250726120200_AddIndexes.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Catalog.Migrations;
+
+public partial class AddIndexes : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_products_Name",
+            schema: "catalog",
+            table: "products",
+            column: "Name");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_products_Category",
+            schema: "catalog",
+            table: "products",
+            column: "Category");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_products_Name",
+            schema: "catalog",
+            table: "products");
+
+        migrationBuilder.DropIndex(
+            name: "IX_products_Category",
+            schema: "catalog",
+            table: "products");
+    }
+}

--- a/services/Catalog/Migrations/CatalogDbContextModelSnapshot.cs
+++ b/services/Catalog/Migrations/CatalogDbContextModelSnapshot.cs
@@ -55,6 +55,10 @@ namespace Catalog.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("Category");
+
+                    b.HasIndex("Name");
+
                     b.ToTable("products", "catalog");
                 });
 #pragma warning restore 612, 618

--- a/services/Order/Controllers/OrdersController.cs
+++ b/services/Order/Controllers/OrdersController.cs
@@ -26,13 +26,13 @@ public class OrdersController(OrderDbContext db) : ControllerBase
         => await db.Orders.Include(o => o.Items).FirstOrDefaultAsync(o => o.Id == id)
             is { } order ? Ok(order) : NotFound();
 
-    public record CreateOrderDto(List<CreateOrderItemDto> Items);
+    public record CreateOrderDto(Guid UserId, List<CreateOrderItemDto> Items);
     public record CreateOrderItemDto(string ProductName, decimal Price);
 
     [HttpPost]
     public async Task<ActionResult<Guid>> Create([FromBody] CreateOrderDto dto)
     {
-        var order = new OrderEntity();
+        var order = new OrderEntity { UserId = dto.UserId };
         foreach (var item in dto.Items)
         {
             order.AddItem(item.ProductName, item.Price);

--- a/services/Order/Domain/OrderEntity.cs
+++ b/services/Order/Domain/OrderEntity.cs
@@ -17,6 +17,7 @@ public enum OrderStatus
 public class OrderEntity
 {
     public Guid Id { get; private set; } = Guid.NewGuid();
+    public Guid UserId { get; set; }
     public List<OrderItem> Items { get; private set; } = new();
     public decimal TotalPrice { get; private set; }
     public OrderStatus Status { get; private set; } = OrderStatus.PendingPayment;

--- a/services/Order/Infrastructure/OrderDbContext.cs
+++ b/services/Order/Infrastructure/OrderDbContext.cs
@@ -15,9 +15,11 @@ public class OrderDbContext(DbContextOptions<OrderDbContext> options) : DbContex
         {
             eb.ToTable("orders");
             eb.HasKey(o => o.Id);
+            eb.Property(o => o.UserId).IsRequired();
             eb.Property(o => o.Status).HasConversion<int>();
             eb.Property(o => o.CreatedAt);
             eb.Property(o => o.TotalPrice).HasColumnType("numeric(12,2)");
+            eb.HasIndex(o => new { o.UserId, o.CreatedAt });
         });
 
         modelBuilder.Entity<OrderItem>(eb =>

--- a/services/Order/Migrations/20250726120100_AddUserId.cs
+++ b/services/Order/Migrations/20250726120100_AddUserId.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Order.Migrations;
+
+public partial class AddUserId : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "UserId",
+            schema: "order",
+            table: "orders",
+            type: "uuid",
+            nullable: false,
+            defaultValue: Guid.Empty);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "CreatedAt",
+            schema: "order",
+            table: "orders",
+            type: "timestamp with time zone",
+            nullable: false,
+            defaultValueSql: "now() at time zone 'utc'");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_orders_UserId_CreatedAt",
+            schema: "order",
+            table: "orders",
+            columns: new[] { "UserId", "CreatedAt" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_orders_UserId_CreatedAt",
+            schema: "order",
+            table: "orders");
+
+        migrationBuilder.DropColumn(
+            name: "UserId",
+            schema: "order",
+            table: "orders");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            schema: "order",
+            table: "orders");
+    }
+}

--- a/services/Order/Migrations/OrderDbContextModelSnapshot.cs
+++ b/services/Order/Migrations/OrderDbContextModelSnapshot.cs
@@ -29,12 +29,20 @@ namespace Order.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
+
                     b.Property<string>("Status")
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
                     b.Property<decimal>("TotalPrice")
                         .HasColumnType("numeric(12,2)");
+
+                    b.HasIndex("UserId", "CreatedAt");
 
                     b.HasKey("Id");
 

--- a/services/Order/debug-order.sh
+++ b/services/Order/debug-order.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run Order service with hot reload for debugging
+cd "$(dirname "$0")"
+dotnet watch run --no-launch-profile

--- a/services/Order/openapi.yaml
+++ b/services/Order/openapi.yaml
@@ -59,10 +59,16 @@ components:
     CreateOrderDto:
       type: object
       properties:
+        userId:
+          type: string
+          format: uuid
         items:
           type: array
           items:
             $ref: '#/components/schemas/CreateOrderItemDto'
+      required:
+        - userId
+        - items
   CreateOrderItemDto:
     type: object
     properties:

--- a/services/User/Infrastructure/UserDbContext.cs
+++ b/services/User/Infrastructure/UserDbContext.cs
@@ -17,6 +17,8 @@ public class UserDbContext(DbContextOptions<UserDbContext> options) : DbContext(
             eb.HasKey(u => u.Id);
             eb.Property(u => u.UserName).HasMaxLength(100);
             eb.Property(u => u.Email).HasMaxLength(200);
+            eb.HasIndex(u => u.UserName).IsUnique();
+            eb.HasIndex(u => u.Email).IsUnique();
         });
     }
 }

--- a/services/User/Migrations/20250726120000_AddUserIndexes.cs
+++ b/services/User/Migrations/20250726120000_AddUserIndexes.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace User.Migrations;
+
+public partial class AddUserIndexes : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_users_UserName",
+            schema: "user",
+            table: "users",
+            column: "UserName",
+            unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_users_Email",
+            schema: "user",
+            table: "users",
+            column: "Email",
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_users_UserName",
+            schema: "user",
+            table: "users");
+        migrationBuilder.DropIndex(
+            name: "IX_users_Email",
+            schema: "user",
+            table: "users");
+    }
+}

--- a/services/User/Migrations/UserDbContextModelSnapshot.cs
+++ b/services/User/Migrations/UserDbContextModelSnapshot.cs
@@ -40,6 +40,12 @@ namespace User.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.HasIndex("Email")
+                        .IsUnique();
+
+                    b.HasIndex("UserName")
+                        .IsUnique();
+
                     b.HasKey("Id");
 
                     b.ToTable("users", "user");

--- a/services/prometheusRule.yaml
+++ b/services/prometheusRule.yaml
@@ -14,6 +14,14 @@ spec:
       annotations:
         summary: "No orders progressing"
         description: "Orders are not transitioning status."
+    - alert: OrdersPendingTooLong
+      expr: increase(orders_created_total[15m]) > 0 and rate(orders_status_changed_total[15m]) == 0
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Orders stuck in pending state"
+        description: "New orders created but no status changes in the last 15 minutes."
   - name: payment.rules
     rules:
     - alert: PaymentFailuresHigh


### PR DESCRIPTION
## Summary
- document DB naming and indexing conventions
- add debug script for Order service
- update monitoring docs with alert rule info
- enforce unique indexes on users
- track user on orders and index for queries
- add indexes on product name and category
- add Prometheus alert for orders stuck in pending
- clarify local test instructions

## Testing
- `PYTHONPATH=$PWD/services/Analytics pytest services/Analytics/tests/test_api.py -q`
- `PYTHONPATH=$PWD/services/Inventory pytest services/Inventory/tests/test_inventory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686d338d9774832e868b26e48447a376