### PR TITLE
Add service communication guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ automatically on first run. Simply execute `./gradlew` in `services/Security`.
 
 ## Service Documentation
 
+- [Database guidelines](docs/database.md)
+- [Monitoring stack](docs/monitoring.md)
+- [Service communication and reliability](docs/service-communication.md)
 
 ## Frontend
 

--- a/docs/service-communication.md
+++ b/docs/service-communication.md
@@ -1,0 +1,15 @@
+# Service Communication and Reliability Guidelines
+
+This document describes recommended practices for communication between services and for keeping the platform reliable as it grows.
+
+## Service Communication Protocols
+
+All external clients interact with the platform via HTTP/REST APIs exposed by the gateway. For performance‑sensitive internal calls, gRPC offers lower overhead and higher throughput than plain HTTP and is therefore preferred. Services can gradually expose gRPC endpoints defined with Protobuf while still presenting RESTful routes through the gateway. Each service may use its language's gRPC client or fall back to HTTP JSON when cross‑language support is simpler.
+
+## Configuration Management and Service Discovery
+
+Managing configuration across many services becomes complex as the system scales. A dedicated configuration service such as Spring Cloud Config, Nacos or Consul allows updating settings like database strings or API keys without redeploying. Service discovery lets instances register themselves so callers can locate them dynamically. In Kubernetes this is handled by DNS, but in docker-compose or bare‑metal environments tools such as Consul or Eureka are useful. The gateway should route requests to available instances based on these registrations.
+
+## Health Checks and Fault Tolerance
+
+Every service should expose a lightweight health endpoint (e.g. `/healthz`). Container orchestrators and load balancers query this endpoint to remove unhealthy instances from rotation. When deployed on Kubernetes configure liveness and readiness probes accordingly. Implement circuit breakers and retries (for example with Polly or Resilience4j) so that failures in one service do not cascade to others. Services are expected to log structured messages and expose Prometheus metrics. Unit and contract tests, debug scripts and alert rules all contribute to a resilient platform.


### PR DESCRIPTION
## Summary
- document recommended protocols for inter-service communication
- link the new guide from the README

## Testing
- `dotnet test Auth/Auth.Tests/Auth.Tests.csproj --verbosity normal`
- `go test ./...` in Payment service
- `poetry run pytest -q` in Analytics, Inventory and Promotion
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_686d3ebfc620832e8e41cf8673a66edd