### PR TITLE
Add Kubernetes deployment guide and manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ automatically on first run. Simply execute `./gradlew` in `services/Security`.
 - [Database guidelines](docs/database.md)
 - [Monitoring stack](docs/monitoring.md)
 - [Service communication and reliability](docs/service-communication.md)
+- [Kubernetes deployment guide](docs/kubernetes.md)
 
 ## Frontend
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,53 @@
+# Kubernetes Deployment Guide
+
+This document describes how to run the microservices on a Kubernetes cluster. It
+complements the existing Docker Compose setup used for local development.
+
+## Overview
+
+Each service is packaged as a Docker image. In production these images can be
+deployed as Kubernetes **Deployments**. A single PostgreSQL instance should be
+provisioned as a **StatefulSet** so that data persists across restarts. The Kong
+gateway runs as a Deployment and exposes HTTP/HTTPS via an **Ingress** resource.
+
+Configuration values such as database credentials or JWT signing keys should be
+stored in **ConfigMaps** and **Secrets** instead of hardcoded compose variables.
+The sample manifests under the `k8s/` folder illustrate this approach.
+
+Horizontal Pod Autoscalers can be added to scale services based on CPU or custom
+metrics. Log output and Prometheus metrics are already supported by the
+applications; simply scrape them using Prometheus and configure alert rules as
+shown in `services/prometheusRule.yaml`.
+
+### Converting Compose to Kubernetes
+
+1. Create a Deployment for each service similar to `k8s/service-deployment.yaml`.
+2. Convert shared services like PostgreSQL using a StatefulSet, see
+   `k8s/postgres-statefulset.yaml`.
+3. Mount configuration via ConfigMaps and Secrets.
+4. Expose the Kong gateway with an Ingress as in
+   `k8s/kong-deployment.yaml`.
+
+These manifests can be managed manually or packaged into a Helm chart. Helm makes
+it easy to provide separate values files for dev, staging and production
+clusters.
+
+## Cloud Environments
+
+On AWS the cluster can run on EKS or ECS Fargate. The database may be hosted on
+RDS PostgreSQL and the frontend served from S3 behind CloudFront. Message queues
+and caches can use managed options such as SQS or ElastiCache. Other cloud
+providers offer similar services if you prefer a vendor neutral setup.
+
+## Additional Recommendations
+
+- Ensure each service logs structured messages so that outputs can be aggregated
+  by tools like Elasticsearch or CloudWatch.
+- Expose Prometheus metrics; these are already available from the gateway and
+  several services.
+- Maintain unit and contract tests as described in `docs/testing.md` to catch
+  regressions before deploying.
+- Use the provided debug scripts (see `docs/debugging.md`) for local
+  troubleshooting.
+- Extend `services/prometheusRule.yaml` with alert rules for your environment.
+

--- a/k8s/kong-deployment.yaml
+++ b/k8s/kong-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kong
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kong
+  template:
+    metadata:
+      labels:
+        app: kong
+    spec:
+      containers:
+        - name: kong
+          image: kong:3.6
+          env:
+            - name: KONG_DATABASE
+              value: off
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /etc/kong/kong.yml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kong
+          ports:
+            - containerPort: 8000
+            - containerPort: 8443
+      volumes:
+        - name: config
+          configMap:
+            name: kong-config
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kong
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kong
+                port:
+                  number: 8000

--- a/k8s/postgres-statefulset.yaml
+++ b/k8s/postgres-statefulset.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          env:
+            - name: POSTGRES_DB
+              value: ecommerce
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/service-deployment.yaml
+++ b/k8s/service-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      labels:
+        app: my-service
+    spec:
+      containers:
+        - name: my-service
+          image: myservice:latest
+          envFrom:
+            - configMapRef:
+                name: my-service-config
+            - secretRef:
+                name: my-service-secret
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: my-service
+  ports:
+    - port: 80
+      targetPort: 8000


### PR DESCRIPTION
## Summary
- document how to deploy the microservices on Kubernetes
- link the new guide from the README
- add example Kubernetes manifests for the gateway, PostgreSQL and a generic service

## Testing
- `poetry run pytest -q` for Analytics
- `poetry run pytest -q` for Inventory
- `poetry run pytest -q` for Promotion
- `poetry run pytest -q` for Review
- `poetry run pytest -q` for Recommendation
- `go test ./cmd/server` for Payment
- `npm test --silent` for frontend


------
https://chatgpt.com/codex/tasks/task_e_686d4eb4cafc832ea522ed5c9535efab