### PR TITLE
Improve input validation and risk checks

### DIFF
--- a/services/Analytics/openapi.yaml
+++ b/services/Analytics/openapi.yaml
@@ -48,9 +48,11 @@ components:
       properties:
         event_type:
           type: string
+          maxLength: 50
         payload:
           type: object
           additionalProperties: true
+          description: JSON object limited to 1000 characters when serialized
       required:
         - event_type
         - payload

--- a/services/Analytics/tests/test_api.py
+++ b/services/Analytics/tests/test_api.py
@@ -27,3 +27,11 @@ async def test_get_metrics():
         resp = await ac.get("/metrics")
         assert resp.status_code == 200
         assert isinstance(resp.json(), dict)
+
+@pytest.mark.asyncio
+async def test_event_payload_too_large():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        big = {"data": "x" * 2000}
+        resp = await ac.post("/events", json={"event_type": "view", "payload": big})
+        assert resp.status_code == 422

--- a/services/Security/src/test/java/com/example/security/controller/RiskCheckTests.java
+++ b/services/Security/src/test/java/com/example/security/controller/RiskCheckTests.java
@@ -1,0 +1,28 @@
+package com.example.security.controller;
+
+import com.example.security.service.AuditService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SecurityController.class)
+@Import(AuditService.class)
+public class RiskCheckTests {
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void suspiciousOrderBlocked() throws Exception {
+        mvc.perform(post("/risk/order-check")
+                .contentType("application/json")
+                .content("{\"userId\":\"fraud\",\"action\":\"order\"}"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("{\"allowed\":false,\"reason\":\"suspicious activity\"}"));
+    }
+}


### PR DESCRIPTION
## Summary
- add event validation and invalid metric to Analytics service
- document JSON payload limit in Analytics API
- test Analytics validation failure
- implement basic risk checking and metric in Security service
- add Security risk check unit test

## Testing
- `poetry run pytest -q` in `services/Analytics`
- `gradle test --no-daemon` *(fails: Unable to run due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686db621d5d8832ebdd2b3cff81f0a48