### PR TITLE
Improve scaling docs and add capacity alert

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,6 +24,14 @@ Grafana supports forecast plugins that extrapolate metric trends. Adding such pa
 
 An example alert rule for latency is included in `services/prometheusRule.yaml` under `notification.rules`. It triggers when the email send P95 latency exceeds one second for five minutes.
 
+When load tests reveal bottlenecks you can scale services in two ways:
+
+- **Vertical scaling** – increase CPU or memory for individual pods or database instances to handle heavier requests.
+- **Horizontal scaling** – run more replicas behind the gateway and spread traffic via the load balancer. Kubernetes Horizontal Pod Autoscalers (HPA) can automatically add or remove pods based on CPU or custom metrics such as QPS.
+- **Stateful components** like PostgreSQL or message queues can be read‑replicated or sharded to improve throughput while keeping writes consistent.
+
+Define capacity alarms so that when average CPU usage stays above 70% for more than ten minutes an alert is raised. See the `capacity.rules` section in `services/prometheusRule.yaml` for a Prometheus example.
+
 ## Error Tracking
 
 Integrate Sentry or a similar platform to collect unhandled exceptions from both backend and frontend code. These reports, combined with Prometheus alerts, enable quick detection of production issues.

--- a/docs/service-communication.md
+++ b/docs/service-communication.md
@@ -13,3 +13,11 @@ Managing configuration across many services becomes complex as the system scales
 ## Health Checks and Fault Tolerance
 
 Every service should expose a lightweight health endpoint (e.g. `/healthz`). Container orchestrators and load balancers query this endpoint to remove unhealthy instances from rotation. When deployed on Kubernetes configure liveness and readiness probes accordingly. Implement circuit breakers and retries (for example with Polly or Resilience4j) so that failures in one service do not cascade to others. Services are expected to log structured messages and expose Prometheus metrics. Unit and contract tests, debug scripts and alert rules all contribute to a resilient platform.
+
+## Graceful Degradation and Rate Limiting
+
+Design fallback behaviour so that critical features continue working when dependencies fail. For example, if the payment gateway is unavailable the Order service should store the order and allow the user to retry payment later or switch to another provider. Non-essential components like recommendations can simply be skipped when they fail.
+
+Apply rate limiting at the gateway to protect backend services during traffic spikes. Limits may be enforced per IP or per user token. Excess requests can be rejected or queued so that core functionality remains responsive.
+
+Combine these techniques with circuit breakers and retries to prevent cascading failures and keep the platform stable during partial outages or sudden load bursts.

--- a/scripts/loadtest.sh
+++ b/scripts/loadtest.sh
@@ -2,12 +2,14 @@
 # Simple load test against the gateway using hey
 
 DURATION=${DURATION:-30s}
+CONCURRENCY=${CONCURRENCY:-50}
 URL=${URL:-http://localhost:8000/api/v1/catalog/products}
+OUTPUT=${OUTPUT:-loadtest.log}
 
 if ! command -v hey >/dev/null 2>&1; then
     echo "hey is required. Install from https://github.com/rakyll/hey" >&2
     exit 1
 fi
 
-echo "Running load test for $DURATION against $URL"
-hey -z "$DURATION" "$URL"
+echo "Running load test for $DURATION with $CONCURRENCY users against $URL"
+hey -z "$DURATION" -c "$CONCURRENCY" "$URL" | tee "$OUTPUT"

--- a/services/prometheusRule.yaml
+++ b/services/prometheusRule.yaml
@@ -86,3 +86,14 @@ spec:
         summary: "Notification latency high"
         description: "P95 email send time exceeded 1s for 5m"
 
+  - name: capacity.rules
+    rules:
+    - alert: ServiceCpuHigh
+      expr: avg by(pod)(rate(container_cpu_usage_seconds_total{image!=""}[5m])) * 100 > 70
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High CPU usage"
+        description: "CPU usage above 70% for 10 minutes. Consider scaling."
+


### PR DESCRIPTION
## Summary
- document strategies for vertical/horizontal scaling and autoscaling
- explain graceful degradation and rate limiting techniques
- enhance loadtest script with concurrency option and logging
- add Prometheus rule to warn when CPU usage is over 70%

## Testing
- `poetry run pytest -q` in `services/Analytics`
- `poetry run pytest -q` in `services/Inventory`
- `poetry run pytest -q` in `services/Review`
- `go test ./...` in `services/Payment`
- `dotnet test` *(fails: command not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc62b678832ea8b88ce25fec1d03