### PR TITLE
Extend frontend for more microservices

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,12 @@ import AddPayment from './pages/AddPayment'
 import Metrics from './pages/Metrics'
 import Login from './pages/Login'
 import RiskCheck from './pages/RiskCheck'
+import Inventory from './pages/Inventory'
+import AddCoupon from './pages/AddCoupon'
+import CouponList from './pages/CouponList'
+import AddReview from './pages/AddReview'
+import ReviewList from './pages/ReviewList'
+import Recommendation from './pages/Recommendation'
 
 export default function App() {
   return (
@@ -29,6 +35,12 @@ export default function App() {
           <Button color="inherit" component={Link} to="/add-shipment">Add Shipment</Button>
           <Button color="inherit" component={Link} to="/payments">Payments</Button>
           <Button color="inherit" component={Link} to="/add-payment">Add Payment</Button>
+          <Button color="inherit" component={Link} to="/coupons">Coupons</Button>
+          <Button color="inherit" component={Link} to="/add-coupon">Add Coupon</Button>
+          <Button color="inherit" component={Link} to="/reviews">Reviews</Button>
+          <Button color="inherit" component={Link} to="/add-review">Add Review</Button>
+          <Button color="inherit" component={Link} to="/recommendations">Recommendations</Button>
+          <Button color="inherit" component={Link} to="/inventory">Inventory</Button>
           <Button color="inherit" component={Link} to="/metrics">Metrics</Button>
           <Button color="inherit" component={Link} to="/risk-check">Risk Check</Button>
           <Button color="inherit" component={Link} to="/login">Login</Button>
@@ -46,6 +58,12 @@ export default function App() {
           <Route path="/add-shipment" element={<AddShipment />} />
           <Route path="/payments" element={<PaymentList />} />
           <Route path="/add-payment" element={<AddPayment />} />
+          <Route path="/coupons" element={<CouponList />} />
+          <Route path="/add-coupon" element={<AddCoupon />} />
+          <Route path="/reviews" element={<ReviewList />} />
+          <Route path="/add-review" element={<AddReview />} />
+          <Route path="/recommendations" element={<Recommendation />} />
+          <Route path="/inventory" element={<Inventory />} />
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/login" element={<Login />} />
           <Route path="/risk-check" element={<RiskCheck />} />

--- a/frontend/src/pages/AddCoupon.tsx
+++ b/frontend/src/pages/AddCoupon.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Container, TextField, Button, Typography } from '@mui/material'
+import api from '../api/api'
+
+export default function AddCoupon() {
+  const [code, setCode] = useState('')
+  const [discount, setDiscount] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await api.post('/api/v1/promotion/coupons', {
+        code,
+        discount: parseFloat(discount),
+      })
+      setCode('')
+      setDiscount('')
+      alert('Coupon created!')
+    } catch (err) {
+      console.error(err)
+      alert('Failed to create coupon')
+    }
+  }
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Add Coupon</Typography>
+      <form onSubmit={handleSubmit}>
+        <TextField label="Code" fullWidth margin="normal" value={code} onChange={e => setCode(e.target.value)} />
+        <TextField label="Discount" fullWidth margin="normal" value={discount} onChange={e => setDiscount(e.target.value)} />
+        <Button variant="contained" type="submit">Add</Button>
+      </form>
+    </Container>
+  )
+}

--- a/frontend/src/pages/AddReview.tsx
+++ b/frontend/src/pages/AddReview.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Container, TextField, Button, Typography } from '@mui/material'
+import api from '../api/api'
+
+export default function AddReview() {
+  const [productId, setProductId] = useState('')
+  const [userId, setUserId] = useState('')
+  const [rating, setRating] = useState('')
+  const [comment, setComment] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await api.post('/api/v1/review/reviews', {
+        product_id: productId,
+        user_id: userId,
+        rating: parseInt(rating, 10),
+        comment,
+      })
+      setProductId('')
+      setUserId('')
+      setRating('')
+      setComment('')
+      alert('Review submitted!')
+    } catch (err) {
+      console.error(err)
+      alert('Failed to submit review')
+    }
+  }
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Add Review</Typography>
+      <form onSubmit={handleSubmit}>
+        <TextField label="Product ID" fullWidth margin="normal" value={productId} onChange={e => setProductId(e.target.value)} />
+        <TextField label="User ID" fullWidth margin="normal" value={userId} onChange={e => setUserId(e.target.value)} />
+        <TextField label="Rating" fullWidth margin="normal" value={rating} onChange={e => setRating(e.target.value)} />
+        <TextField label="Comment" fullWidth margin="normal" value={comment} onChange={e => setComment(e.target.value)} />
+        <Button variant="contained" type="submit">Submit</Button>
+      </form>
+    </Container>
+  )
+}

--- a/frontend/src/pages/CouponList.tsx
+++ b/frontend/src/pages/CouponList.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { Container, Typography, Card, CardContent } from '@mui/material'
+import api from '../api/api'
+
+interface Coupon {
+  code: string
+  discount: number
+}
+
+export default function CouponList() {
+  const [coupons, setCoupons] = useState<Coupon[]>([])
+
+  useEffect(() => {
+    api.get('/api/v1/promotion/coupons')
+      .then(res => setCoupons(res.data))
+      .catch(err => console.error(err))
+  }, [])
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Coupons</Typography>
+      {coupons.map(c => (
+        <Card key={c.code} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6">{c.code}</Typography>
+            <Typography>Discount: {c.discount}</Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Container>
+  )
+}

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { Container, TextField, Button, Typography } from '@mui/material'
+import api from '../api/api'
+
+export default function Inventory() {
+  const [productId, setProductId] = useState('')
+  const [quantity, setQuantity] = useState('')
+  const [stock, setStock] = useState<string | null>(null)
+
+  const getStock = async () => {
+    try {
+      const res = await api.get(`/api/v1/inventory/${productId}`)
+      setStock(JSON.stringify(res.data))
+    } catch (err) {
+      console.error(err)
+      alert('Failed to fetch stock')
+    }
+  }
+
+  const reserve = async () => {
+    try {
+      await api.post('/api/v1/inventory/reserve', {
+        product_id: productId,
+        quantity: parseInt(quantity, 10),
+      })
+      alert('Reserved!')
+    } catch (err) {
+      console.error(err)
+      alert('Failed to reserve stock')
+    }
+  }
+
+  const release = async () => {
+    try {
+      await api.post('/api/v1/inventory/release', {
+        product_id: productId,
+        quantity: parseInt(quantity, 10),
+      })
+      alert('Released!')
+    } catch (err) {
+      console.error(err)
+      alert('Failed to release stock')
+    }
+  }
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Inventory</Typography>
+      <TextField label="Product ID" fullWidth margin="normal" value={productId} onChange={e => setProductId(e.target.value)} />
+      <TextField label="Quantity" fullWidth margin="normal" value={quantity} onChange={e => setQuantity(e.target.value)} />
+      <Button variant="contained" onClick={getStock} sx={{ mr: 1 }}>Get Stock</Button>
+      <Button variant="contained" onClick={reserve} sx={{ mr: 1 }}>Reserve</Button>
+      <Button variant="contained" onClick={release}>Release</Button>
+      {stock && (
+        <Typography sx={{ mt: 2 }}><pre>{stock}</pre></Typography>
+      )}
+    </Container>
+  )
+}

--- a/frontend/src/pages/Recommendation.tsx
+++ b/frontend/src/pages/Recommendation.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import { Container, TextField, Button, Typography, List, ListItem } from '@mui/material'
+import api from '../api/api'
+
+export default function Recommendation() {
+  const [productId, setProductId] = useState('')
+  const [items, setItems] = useState<string[]>([])
+
+  const handleFetch = async () => {
+    try {
+      const res = await api.get(`/api/v1/recommendation/recommendations/${productId}`)
+      setItems(res.data)
+    } catch (err) {
+      console.error(err)
+      alert('Failed to fetch recommendations')
+    }
+  }
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Recommendations</Typography>
+      <TextField label="Product ID" fullWidth margin="normal" value={productId} onChange={e => setProductId(e.target.value)} />
+      <Button variant="contained" onClick={handleFetch} sx={{ mb: 2 }}>Get</Button>
+      <List>
+        {items.map((it, idx) => (
+          <ListItem key={idx}>{it}</ListItem>
+        ))}
+      </List>
+    </Container>
+  )
+}

--- a/frontend/src/pages/ReviewList.tsx
+++ b/frontend/src/pages/ReviewList.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Container, TextField, Button, Typography, Card, CardContent } from '@mui/material'
+import api from '../api/api'
+
+interface Review {
+  product_id: string
+  user_id: string
+  rating: number
+  comment: string
+}
+
+export default function ReviewList() {
+  const [productId, setProductId] = useState('')
+  const [reviews, setReviews] = useState<Review[]>([])
+
+  const handleFetch = async () => {
+    try {
+      const res = await api.get(`/api/v1/review/reviews/${productId}`)
+      setReviews(res.data)
+    } catch (err) {
+      console.error(err)
+      alert('Failed to fetch reviews')
+    }
+  }
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Reviews</Typography>
+      <TextField label="Product ID" fullWidth margin="normal" value={productId} onChange={e => setProductId(e.target.value)} />
+      <Button variant="contained" onClick={handleFetch} sx={{ mb: 2 }}>Load</Button>
+      {reviews.map((r, idx) => (
+        <Card key={idx} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography>Product: {r.product_id}</Typography>
+            <Typography>User: {r.user_id}</Typography>
+            <Typography>Rating: {r.rating}</Typography>
+            <Typography>{r.comment}</Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Container>
+  )
+}


### PR DESCRIPTION
## Summary
- support new microservice pages: inventory, coupon, review and recommendation
- wire new pages into navigation and routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dcb7bb630832ea6fd033d066acc2a