### PR TITLE
Fix NuGet source URLs

### DIFF
--- a/services/Auth/Dockerfile
+++ b/services/Auth/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Auth.csproj", "."]
-RUN dotnet nuget add source https://mirrors.aliyun.com/nuget/v3/index.json -n aliyun \
+RUN dotnet nuget add source https://nuget.aliyun.com/repository/nuget/v3/index.json -n aliyun \
     && dotnet restore "./Auth.csproj" \
-        --source https://mirrors.aliyun.com/nuget/v3/index.json
+        --source https://nuget.aliyun.com/repository/nuget/v3/index.json
 COPY . .
 RUN dotnet build "Auth.csproj" -c Release -o /app/build
 RUN dotnet publish "Auth.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Cart/Dockerfile
+++ b/services/Cart/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Cart.csproj", "."]
-RUN dotnet nuget add source https://mirrors.aliyun.com/nuget/v3/index.json -n aliyun \
+RUN dotnet nuget add source https://nuget.aliyun.com/repository/nuget/v3/index.json -n aliyun \
     && dotnet restore "./Cart.csproj" \
-        --source https://mirrors.aliyun.com/nuget/v3/index.json
+        --source https://nuget.aliyun.com/repository/nuget/v3/index.json
 COPY . .
 RUN dotnet build "Cart.csproj" -c Release -o /app/build
 RUN dotnet publish "Cart.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Catalog/Dockerfile
+++ b/services/Catalog/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Catalog.csproj", "."]
-RUN dotnet nuget add source https://mirrors.aliyun.com/nuget/v3/index.json -n aliyun \
+RUN dotnet nuget add source https://nuget.aliyun.com/repository/nuget/v3/index.json -n aliyun \
     && dotnet restore "./Catalog.csproj" \
-        --source https://mirrors.aliyun.com/nuget/v3/index.json
+        --source https://nuget.aliyun.com/repository/nuget/v3/index.json
 COPY . .
 RUN dotnet build "Catalog.csproj" -c Release -o /app/build
 RUN dotnet publish "Catalog.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Order/Dockerfile
+++ b/services/Order/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Order.csproj", "."]
-RUN dotnet nuget add source https://mirrors.aliyun.com/nuget/v3/index.json -n aliyun \
+RUN dotnet nuget add source https://nuget.aliyun.com/repository/nuget/v3/index.json -n aliyun \
     && dotnet restore "./Order.csproj" \
-        --source https://mirrors.aliyun.com/nuget/v3/index.json
+        --source https://nuget.aliyun.com/repository/nuget/v3/index.json
 COPY . .
 RUN dotnet build "Order.csproj" -c Release -o /app/build
 RUN dotnet publish "Order.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Shipping/Dockerfile
+++ b/services/Shipping/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Shipping.csproj", "."]
-RUN dotnet nuget add source https://mirrors.aliyun.com/nuget/v3/index.json -n aliyun \
+RUN dotnet nuget add source https://nuget.aliyun.com/repository/nuget/v3/index.json -n aliyun \
     && dotnet restore "./Shipping.csproj" \
-        --source https://mirrors.aliyun.com/nuget/v3/index.json
+        --source https://nuget.aliyun.com/repository/nuget/v3/index.json
 COPY . .
 RUN dotnet build "Shipping.csproj" -c Release -o /app/build
 RUN dotnet publish "Shipping.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/User/Dockerfile
+++ b/services/User/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["User.csproj", "."]
-RUN dotnet nuget add source https://mirrors.aliyun.com/nuget/v3/index.json -n aliyun \
+RUN dotnet nuget add source https://nuget.aliyun.com/repository/nuget/v3/index.json -n aliyun \
     && dotnet restore "./User.csproj" \
-        --source https://mirrors.aliyun.com/nuget/v3/index.json
+        --source https://nuget.aliyun.com/repository/nuget/v3/index.json
 COPY . .
 RUN dotnet build "User.csproj" -c Release -o /app/build
 RUN dotnet publish "User.csproj" -c Release -o /app/publish /p:UseAppHost=false


### PR DESCRIPTION
## Summary
- update NuGet mirror in all dotnet service Dockerfiles

## Testing
- `dotnet test` for Auth, Cart, Catalog, Order, Shipping and User services
- `poetry run pytest -q` for Analytics and Inventory
- `npm test --silent` for frontend

------
https://chatgpt.com/codex/tasks/task_e_687b9f0abd0c832ea8673d57e7992d4f