### PR TITLE
Fix NuGet sources in .NET Dockerfiles

### DIFF
--- a/services/Auth/Dockerfile
+++ b/services/Auth/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Auth.csproj", "."]
-RUN dotnet nuget add source https://pypi.tuna.tsinghua.edu.cn/simple -n tuna \
-    && dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
     && dotnet restore "./Auth.csproj" \
-        --source https://pypi.tuna.tsinghua.edu.cn/simple \
         --source https://mirrors.cloud.tencent.com/nuget/index.json
 COPY . .
 RUN dotnet build "Auth.csproj" -c Release -o /app/build

--- a/services/Cart/Dockerfile
+++ b/services/Cart/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Cart.csproj", "."]
-RUN dotnet nuget add source https://pypi.tuna.tsinghua.edu.cn/simple -n tuna \
-    && dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
     && dotnet restore "./Cart.csproj" \
-        --source https://pypi.tuna.tsinghua.edu.cn/simple \
         --source https://mirrors.cloud.tencent.com/nuget/index.json
 COPY . .
 RUN dotnet build "Cart.csproj" -c Release -o /app/build

--- a/services/Catalog/Dockerfile
+++ b/services/Catalog/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Catalog.csproj", "."]
-RUN dotnet nuget add source https://pypi.tuna.tsinghua.edu.cn/simple -n tuna \
-    && dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
     && dotnet restore "./Catalog.csproj" \
-        --source https://pypi.tuna.tsinghua.edu.cn/simple \
         --source https://mirrors.cloud.tencent.com/nuget/index.json
 COPY . .
 RUN dotnet build "Catalog.csproj" -c Release -o /app/build

--- a/services/Order/Dockerfile
+++ b/services/Order/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Order.csproj", "."]
-RUN dotnet nuget add source https://pypi.tuna.tsinghua.edu.cn/simple -n tuna \
-    && dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
     && dotnet restore "./Order.csproj" \
-        --source https://pypi.tuna.tsinghua.edu.cn/simple \
         --source https://mirrors.cloud.tencent.com/nuget/index.json
 COPY . .
 RUN dotnet build "Order.csproj" -c Release -o /app/build

--- a/services/Shipping/Dockerfile
+++ b/services/Shipping/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Shipping.csproj", "."]
-RUN dotnet nuget add source https://pypi.tuna.tsinghua.edu.cn/simple -n tuna \
-    && dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
     && dotnet restore "./Shipping.csproj" \
-        --source https://pypi.tuna.tsinghua.edu.cn/simple \
         --source https://mirrors.cloud.tencent.com/nuget/index.json
 COPY . .
 RUN dotnet build "Shipping.csproj" -c Release -o /app/build

--- a/services/User/Dockerfile
+++ b/services/User/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["User.csproj", "."]
-RUN dotnet nuget add source https://pypi.tuna.tsinghua.edu.cn/simple -n tuna \
-    && dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
     && dotnet restore "./User.csproj" \
-        --source https://pypi.tuna.tsinghua.edu.cn/simple \
         --source https://mirrors.cloud.tencent.com/nuget/index.json
 COPY . .
 RUN dotnet build "User.csproj" -c Release -o /app/build


### PR DESCRIPTION
## Summary
- remove PyPI source from .NET Dockerfiles
- keep only the Tencent mirror as NuGet source

## Testing
- `dotnet test` for each .NET service
- `go test ./...` in `services/Payment`
- `poetry run pytest` for Analytics and Inventory
- `poetry run pytest` for Admin, Notification, Promotion, Recommendation and Review
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cf5ddb8a8832e9b35a246b5f5fe84