### PR TITLE
Update dotnet mirror sources

### DIFF
--- a/services/Auth/Dockerfile
+++ b/services/Auth/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Auth.csproj", "."]
-RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json -n tsinghua \
+    && dotnet nuget add source https://nuget.azure.cn/v3/index.json -n azure \
     && dotnet restore "./Auth.csproj" \
-        --source https://mirrors.cloud.tencent.com/nuget/index.json
+        --source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json \
+        --source https://nuget.azure.cn/v3/index.json
 COPY . .
 RUN dotnet build "Auth.csproj" -c Release -o /app/build
 RUN dotnet publish "Auth.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Cart/Dockerfile
+++ b/services/Cart/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Cart.csproj", "."]
-RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json -n tsinghua \
+    && dotnet nuget add source https://nuget.azure.cn/v3/index.json -n azure \
     && dotnet restore "./Cart.csproj" \
-        --source https://mirrors.cloud.tencent.com/nuget/index.json
+        --source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json \
+        --source https://nuget.azure.cn/v3/index.json
 COPY . .
 RUN dotnet build "Cart.csproj" -c Release -o /app/build
 RUN dotnet publish "Cart.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Catalog/Dockerfile
+++ b/services/Catalog/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Catalog.csproj", "."]
-RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json -n tsinghua \
+    && dotnet nuget add source https://nuget.azure.cn/v3/index.json -n azure \
     && dotnet restore "./Catalog.csproj" \
-        --source https://mirrors.cloud.tencent.com/nuget/index.json
+        --source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json \
+        --source https://nuget.azure.cn/v3/index.json
 COPY . .
 RUN dotnet build "Catalog.csproj" -c Release -o /app/build
 RUN dotnet publish "Catalog.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Order/Dockerfile
+++ b/services/Order/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Order.csproj", "."]
-RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json -n tsinghua \
+    && dotnet nuget add source https://nuget.azure.cn/v3/index.json -n azure \
     && dotnet restore "./Order.csproj" \
-        --source https://mirrors.cloud.tencent.com/nuget/index.json
+        --source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json \
+        --source https://nuget.azure.cn/v3/index.json
 COPY . .
 RUN dotnet build "Order.csproj" -c Release -o /app/build
 RUN dotnet publish "Order.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/Shipping/Dockerfile
+++ b/services/Shipping/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Shipping.csproj", "."]
-RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json -n tsinghua \
+    && dotnet nuget add source https://nuget.azure.cn/v3/index.json -n azure \
     && dotnet restore "./Shipping.csproj" \
-        --source https://mirrors.cloud.tencent.com/nuget/index.json
+        --source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json \
+        --source https://nuget.azure.cn/v3/index.json
 COPY . .
 RUN dotnet build "Shipping.csproj" -c Release -o /app/build
 RUN dotnet publish "Shipping.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/services/User/Dockerfile
+++ b/services/User/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["User.csproj", "."]
-RUN dotnet nuget add source https://mirrors.cloud.tencent.com/nuget/index.json -n tencent \
+RUN dotnet nuget add source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json -n tsinghua \
+    && dotnet nuget add source https://nuget.azure.cn/v3/index.json -n azure \
     && dotnet restore "./User.csproj" \
-        --source https://mirrors.cloud.tencent.com/nuget/index.json
+        --source https://mirrors.tuna.tsinghua.edu.cn/nuget/index.json \
+        --source https://nuget.azure.cn/v3/index.json
 COPY . .
 RUN dotnet build "User.csproj" -c Release -o /app/build
 RUN dotnet publish "User.csproj" -c Release -o /app/publish /p:UseAppHost=false


### PR DESCRIPTION
## Summary
- change NuGet mirrors to use Tsinghua as primary and Azure China as fallback
- keep .NET 8 across cart, catalog, auth, shipping, user and order services

## Testing
- `dotnet test services/Cart/Cart.Tests/Cart.Tests.csproj`
- `dotnet test services/Catalog/Catalog.Tests/Catalog.Tests.csproj`
- `dotnet test services/Auth/Auth.Tests/Auth.Tests.csproj`
- `dotnet test services/Shipping/Shipping.Tests/Shipping.Tests.csproj`
- `dotnet test services/User/User.Tests/User.Tests.csproj`
- `dotnet test services/Order/Order.Tests/Order.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_687dbe892400832e8b41c0ef81418c17