### PR TITLE
Fix workflow syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Run .NET tests
         run: |
           for proj in services/*/*.Tests/*.csproj; do
             echo "Testing $proj"


### PR DESCRIPTION
## Summary
- split Node.js setup and test run steps in CI workflow

## Testing
- `pytest -q` inside `services/Inventory`
- `pytest -q` inside `services/Admin`
- `pytest -q` inside `services/Analytics`
- `pytest -q` inside `services/Notification`
- `pytest -q` inside `services/Promotion`
- `pytest -q` inside `services/Recommendation`
- `pytest -q` inside `services/Review`


------
https://chatgpt.com/codex/tasks/task_e_6880b0853c44832ebedcc74331a38154