### PR TITLE
Fix decK usage in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,10 @@ jobs:
             dotnet test "$proj" --no-build --collect:"XPlat Code Coverage"
           done
 
+      - name: Setup decK
+        uses: kong/setup-deck@v1
       - name: Sync Kong config
-        uses: kong/deck@v1
-        with:
-          command: sync
-          config: services/Gateway/kong.yml
+        run: deck sync --state services/Gateway/kong.yml
       - name: Push images
         if: github.ref == 'refs/heads/main'
         run: docker compose -f services/docker-compose.yml push


### PR DESCRIPTION
## Summary
- install decK using Kong's action
- run `deck` manually

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880cf8fee24832eaef199bf3945c48b