### PR TITLE
Fix .NET test invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           for proj in services/*/*.Tests/*.csproj; do
             echo "Testing $proj"
-            dotnet test "$proj" --no-build --collect:"XPlat Code Coverage"
+            dotnet test --no-build --collect:"XPlat Code Coverage" "$proj"
           done
 
       - name: Setup decK

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -21,7 +21,7 @@ Run unit tests for all services before committing:
 ```bash
 # .NET services
 for proj in services/*/*.Tests/*.csproj; do
-    dotnet test "$proj" --no-build
+    dotnet test --no-build "$proj"
 done
 
 # Go service


### PR DESCRIPTION
## Summary
- fix how `dotnet test` is called so that options come before the project path
- update docs to use the corrected command

## Testing
- `npm test --silent` *(fails: jest not found)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: pytest_asyncio)*
- `dotnet test services/Auth/Auth.Tests/Auth.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e9f0bf14832eb3e87a05dd40383e