### PR TITLE
Fix Kong startup shell in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,26 @@ jobs:
 
       - name: Setup decK
         uses: kong/setup-deck@v1
+      - name: Start Kong Gateway
+        shell: bash
+        run: |
+          docker run -d --name kong-test \
+            -p 8001:8001 \
+            -e KONG_DATABASE=off \
+            -e KONG_DECLARATIVE_CONFIG=/kong/kong.yml \
+            -e KONG_ADMIN_LISTEN=0.0.0.0:8001 \
+            -v ${{ github.workspace }}/services/Gateway/kong.yml:/kong/kong.yml \
+            kong:3
+          for i in {1..10}; do
+            if curl -s http://localhost:8001/status > /dev/null; then
+              break
+            fi
+            sleep 5
+          done
       - name: Sync Kong config
         run: deck sync --state services/Gateway/kong.yml
+      - name: Stop Kong Gateway
+        run: docker rm -f kong-test
       - name: Push images
         if: github.ref == 'refs/heads/main'
         run: docker compose -f services/docker-compose.yml push


### PR DESCRIPTION
## Summary
- use bash shell when starting the Kong container in the CI workflow

## Testing
- `PYTHONPATH=. poetry run pytest -q` in `services/Analytics` ✅
- `go test ./...` in `services/Payment` ✅
- `docker-compose -f services/docker-compose.tests.yml up --abort-on-container-exit` ❌ (failed: Docker daemon couldn't start)


------
https://chatgpt.com/codex/tasks/task_e_6880f6005258832eb09df4f06dd0b7c2