### PR TITLE
Fix CI by installing Poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install Poetry
+        run: |
+          pip install poetry
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'


### PR DESCRIPTION
## Summary
- fix GitHub workflow so Python tests have Poetry available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881a92a376c832ea92cb645c9444ce6