### PR TITLE
Fix Poetry path in GitHub Actions

### DIFF
--- a/.github/workflows/analytics-ci.yml
+++ b/.github/workflows/analytics-ci.yml
@@ -18,7 +18,8 @@ jobs:
           python-version: '3.12'
       - name: Install Poetry
         run: |
-          pip install poetry
+          pip install --user poetry
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies
         working-directory: services/Analytics
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
           python-version: '3.12'
       - name: Install Poetry
         run: |
-          pip install poetry
+          pip install --user poetry
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'


### PR DESCRIPTION
## Summary
- fix path for Poetry in CI workflow
- fix path for Poetry in analytics CI workflow

## Testing
- `poetry run pytest -q` in services/Analytics
- `poetry run pytest -q` in services/Inventory
- `poetry run pytest -q` in services/Admin
- `npm ci --legacy-peer-deps` and `npm test --silent` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6881ab829e54832eaa75d842ad04c0cc