### PR TITLE
Fix CI Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         run: deck sync --state services/Gateway/kong.yml --kong-addr http://127.0.0.1:8001
       - name: Stop Kong Gateway
         run: docker rm -f kong-test
+      - name: Build images
+        run: docker compose -f services/docker-compose.yml build
       - name: Push images
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
         run: docker compose -f services/docker-compose.yml push

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -64,9 +64,10 @@ See [testing.md](testing.md) for details.
 ## 4. Continuous Integration
 
 A GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push. It now:
-
-
-
+- installs Python, Go, .NET and Node toolchains
+- runs service and frontend tests
+- builds the Docker images defined in `services/docker-compose.yml`
+- pushes the images when changes land on the main branch
 ## 5. API Gateway
 
 The stack uses [Kong Gateway 3.x](https://docs.konghq.com/gateway/) running from the `services/Gateway` container. Routes are declared in `kong.yml` and share the `/api/v1/` prefix. Kong applies authentication, authorisation and rate limiting while exposing Prometheus metrics. When a new service is added, generate its `openapi.yaml`, update `kong.yml` and let the CI pipeline sync the gateway.


### PR DESCRIPTION
## Summary
- build Docker images before pushing them in CI
- document CI workflow steps in PROCESS.md

## Testing
- `poetry run pytest -q` for Analytics service
- `npm test --silent` in frontend
- `poetry run pytest -q` for Inventory service

------
https://chatgpt.com/codex/tasks/task_e_6881ae4a7798832e863c5ab95bff09bb