### PR TITLE
Fix analytics tests and build

### DIFF
--- a/services/Analytics/Dockerfile
+++ b/services/Analytics/Dockerfile
@@ -15,7 +15,6 @@ RUN poetry config virtualenvs.create false \
 
 # 4. Copy source code and install root package
 COPY ./app ./app
-COPY .env .env
 RUN poetry install --no-interaction --no-ansi              # install root package
 
 # 5. Run the service

--- a/services/Analytics/app/db.py
+++ b/services/Analytics/app/db.py
@@ -6,11 +6,10 @@ from dotenv import load_dotenv
 # Load environment variables from a .env file if present
 load_dotenv()
 
-# Prefer the service-specific variable name used in docs and tests.
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-# ãȷȡ
-print("DATABASE_URL =", DATABASE_URL)
+# Use an in-memory SQLite database by default so tests can run without
+# external configuration. This value can still be overridden via the
+# ``DATABASE_URL`` environment variable or a ``.env`` file.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
 engine = create_async_engine(DATABASE_URL, echo=False)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)


### PR DESCRIPTION
## Summary
- default `DATABASE_URL` to an in-memory SQLite database so tests run without extra config
- keep Dockerfile from failing when `.env` isn't present (previous commit)

## Testing
- `poetry install --no-interaction` in `services/Analytics`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b346328c832e841bcd080179d61f