### PR TITLE
Fix Security Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ docker-compose.override.yml
 # Ignore TLS certificates but keep a placeholder file
 services/Gateway/certs/*
 !services/Gateway/certs/.gitkeep
+.coverage

--- a/services/Security/Dockerfile
+++ b/services/Security/Dockerfile
@@ -1,7 +1,6 @@
 FROM eclipse-temurin:17-jdk-jammy AS builder
 WORKDIR /workspace
 
-COPY gradle-8.14.2/gradle-8.14.2-bin.zip gradle-8.14.2/
 COPY gradlew gradlew
 COPY gradle  gradle
 COPY build.gradle settings.gradle ./


### PR DESCRIPTION
## Summary
- remove COPY for gradle distribution in `services/Security/Dockerfile`

## Testing
- `poetry run pytest -q` in `services/Admin`
- `poetry run pytest --cov` in `services/Analytics`
- `poetry run pytest -q` in `services/Inventory`
- `npm test --silent` in `frontend`
- ❌ `docker build` *(fails: `docker` not found)*
- ❌ `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b8926940832e831a432ab01edd6e