### PR TITLE
Fix Admin service Docker build

### DIFF
--- a/services/Admin/Dockerfile
+++ b/services/Admin/Dockerfile
@@ -5,6 +5,7 @@ RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
         --default-timeout=120 poetry && \
     poetry config virtualenvs.create false && \
     poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi
+    poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
+RUN poetry install --no-interaction --no-ansi
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- copy Admin service code before installing root package
- install dependencies first then local package in Admin Dockerfile

## Testing
- `poetry run pytest -q` in `services/Admin`


------
https://chatgpt.com/codex/tasks/task_e_6881f065d724832eb4ebf90780efa7cc