### PR TITLE
Fix Docker push permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +77,12 @@ jobs:
         run: docker rm -f kong-test
       - name: Build images
         run: docker compose -f services/docker-compose.yml build
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push images
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
         run: docker compose -f services/docker-compose.yml push


### PR DESCRIPTION
## Summary
- grant packages:write to GITHUB_TOKEN for CI
- log in to ghcr.io before pushing images

## Testing
- `npm test --silent`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f50acc30832eabc7f3b5e9c5b77b