### PR TITLE
Fix workflow registry name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,13 @@ jobs:
         run: deck sync --state services/Gateway/kong.yml --kong-addr http://127.0.0.1:8001
       - name: Stop Kong Gateway
         run: docker rm -f kong-test
+      - name: Set lowercase registry
+        run: echo "REGISTRY=$(echo ghcr.io/${{ github.repository_owner }}/ | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Build images
         run: docker compose -f services/docker-compose.yml build
         env:
-          REGISTRY: ghcr.io/${{ github.repository_owner }}/
+          REGISTRY: ${{ env.REGISTRY }}
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -89,5 +92,5 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
         run: docker compose -f services/docker-compose.yml push
         env:
-          REGISTRY: ghcr.io/${{ github.repository_owner }}/
+          REGISTRY: ${{ env.REGISTRY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,12 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
         run: |
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           for d in services/*/Dockerfile; do
             name=$(basename $(dirname $d) | tr '[:upper:]' '[:lower:]')
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
-              --tag ghcr.io/${{ github.repository_owner }}/$name:$VERSION \
+              --tag ghcr.io/$owner/$name:$VERSION \
               --push \
               -f $d $(dirname $d)
           done


### PR DESCRIPTION
## Summary
- normalize registry owner to lowercase in CI workflow
- normalize registry owner to lowercase in release workflow

## Testing
- `poetry run pytest -q` in services/Analytics
- `poetry run pytest -q` in services/Inventory
- `poetry run pytest -q` in services/Promotion
- `poetry run pytest -q` in services/Review
- `poetry run pytest -q` in services/Recommendation
- `poetry run pytest -q` in services/Notification
- `npm test --silent` in frontend
- `go test ./...` in services/Payment
- `dotnet test Auth.Tests/Auth.Tests.csproj -l "console;verbosity=normal"` in services/Auth

------
https://chatgpt.com/codex/tasks/task_e_68820137874c832e914a9f1eba572bad