### PR TITLE
Fix compose env issues and inventory DSN

### DIFF
--- a/services/.env
+++ b/services/.env
@@ -1,4 +1,4 @@
-﻿DB_USER=catalog_admin
+DB_USER=catalog_admin
 DB_PASSWORD=changeme
 DB_NAME=catalog
 # Prefix to pull images from GitHub Container Registry

--- a/services/Gateway/docker-compose.yml
+++ b/services/Gateway/docker-compose.yml
@@ -44,11 +44,8 @@ services:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /kong/kong.yml  # 注意路径
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
-      KONG_SSL_CERT: /certs/gateway.crt
-      KONG_SSL_CERT_KEY: /certs/gateway.key
     volumes:
       - ./kong.yml:/kong/kong.yml
-      - ./certs:/certs:ro
 volumes:
   pgdata:
 

--- a/services/Inventory/docker-compose.yml
+++ b/services/Inventory/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: inventory-api
     restart: unless-stopped
     environment:
-      POSTGRES_DSN: "postgres://${DB_USER:-catalog_admin}:${DB_PASSWORD}@pg:5432/${DB_NAME:-catalog}?sslmode=disable"
+      POSTGRES_DSN: "postgresql://${DB_USER:-catalog_admin}:${DB_PASSWORD}@pg:5432/${DB_NAME:-catalog}?sslmode=disable"
     ports:
       - "8210:8000"
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     environment:
       # Go's lib/pq driver expects a DSN in URI or key=value form, not the
       # semicolon style used by the .NET services.
-      POSTGRES_DSN: "postgres://${DB_USER:-catalog_admin}:${DB_PASSWORD}@pg:5432/${DB_NAME:-catalog}?sslmode=disable"
+      POSTGRES_DSN: "postgresql://${DB_USER:-catalog_admin}:${DB_PASSWORD}@pg:5432/${DB_NAME:-catalog}?sslmode=disable"
     ports:
       - "7001:7001"
       - "7002:8080"
@@ -123,7 +123,7 @@ services:
       - pg
     restart: unless-stopped
     environment:
-      POSTGRES_DSN: "postgres://${DB_USER:-catalog_admin}:${DB_PASSWORD}@pg:5432/${DB_NAME:-catalog}?sslmode=disable"
+      POSTGRES_DSN: "postgresql://${DB_USER:-catalog_admin}:${DB_PASSWORD}@pg:5432/${DB_NAME:-catalog}?sslmode=disable"
     ports:
       - "8210:8000"
 
@@ -267,11 +267,8 @@ services:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /kong/kong.yml
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
-      KONG_SSL_CERT: /certs/gateway.crt
-      KONG_SSL_CERT_KEY: /certs/gateway.key
     volumes:
       - ./Gateway/kong.yml:/kong/kong.yml
-      - ./Gateway/certs:/certs:ro
 
   frontend:
     build:


### PR DESCRIPTION
## Summary
- remove BOM from services/.env so docker compose picks up variables correctly
- use `postgresql://` DSN for inventory api
- drop kong cert settings so gateway works without local TLS files

## Testing
- `poetry run pytest` in `services/Analytics`
- `poetry run pytest` in `services/Inventory`
- `poetry run pytest` in `services/Notification`
- ❌ `docker compose` (docker not installed)
- ❌ `dotnet test` (dotnet not installed)


------
https://chatgpt.com/codex/tasks/task_e_68823d5d7bac832eb1b9e760fd2d5f11