### PR TITLE
Fix gateway certs and inventory DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ hey -z 30s http://localhost/api/v1/catalog/products
 
 ## Building and Running
 
-From the `services` directory you can spin up the entire stack. Copy `.env.example` to `.env` and adjust the values to set database credentials before launching:
+From the `services` directory you can spin up the entire stack. Copy `.env.example` **into that folder** as `.env` and adjust the values to set database credentials before launching:
 
 ```bash
 docker compose up --build
 ```
 
 The gateway also serves HTTPS traffic on `https://localhost:8443`. Provide your
-own TLS key and certificate under `services/Gateway/certs` so they are mounted
-into the container at startup. A self-signed pair can be created with:
+own TLS key and certificate under `services/Gateway/certs` so they are automatically
+mounted into the container. A self-signed pair can be created with:
 ```bash
 openssl req -x509 -nodes -newkey rsa:2048 -keyout services/Gateway/certs/gateway.key \
   -out services/Gateway/certs/gateway.crt -subj '/CN=localhost'

--- a/services/Gateway/docker-compose.yml
+++ b/services/Gateway/docker-compose.yml
@@ -44,8 +44,11 @@ services:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /kong/kong.yml  # 注意路径
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_SSL_CERT: /certs/gateway.crt
+      KONG_SSL_CERT_KEY: /certs/gateway.key
     volumes:
       - ./kong.yml:/kong/kong.yml
+      - ./certs:/certs:ro
 volumes:
   pgdata:
 

--- a/services/Inventory/app/db.py
+++ b/services/Inventory/app/db.py
@@ -3,6 +3,9 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 import os
 
 POSTGRES_DSN = os.getenv("POSTGRES_DSN")
+if POSTGRES_DSN and POSTGRES_DSN.startswith("postgres://"):
+    # Ensure SQLAlchemy uses the correct PostgreSQL driver
+    POSTGRES_DSN = POSTGRES_DSN.replace("postgres://", "postgresql+psycopg2://", 1)
 engine = create_engine(POSTGRES_DSN or "sqlite:///inventory.db", future=True)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 Base = declarative_base()


### PR DESCRIPTION
## Summary
- mount TLS certs for Kong gateway and set SSL variables
- normalize Inventory DSN if using `postgres://` prefix
- clarify `.env` placement in README

## Testing
- `pytest services/Inventory/tests/test_inventory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ed48f700832eaec275be9f819332