### PR TITLE
Add per-service Docker build workflow

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,35 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/**/Dockerfile'
+      - '.github/workflows/docker-images.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        service: [Admin, Analytics, Auth, Cart, Catalog, Gateway, Inventory, Notification, Order, Payment, Promotion, Recommendation, Review, Security, Shipping, User]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: |
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$owner/${{ matrix.service }}.api:latest \
+            --push \
+            -f services/${{ matrix.service }}/Dockerfile services/${{ matrix.service }}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ automatically on first run. Simply execute `./gradlew` in `services/Security`.
 - [Service communication and reliability](docs/service-communication.md)
 - [Kubernetes deployment guide](docs/kubernetes.md)
 - [Security best practices](docs/security-best-practices.md)
+- [Docker image registry](docs/registry.md)
 
 ## Frontend
 

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -90,5 +90,8 @@ The gateway keeps the services isolated and enforces contract-based routing.
 5. Create a version tag (`vMAJOR.MINOR.PATCH`) so `release.yml` can publish the
    multi-architecture images and generate release notes
 
+For details on how the images are built and where to pull them from, see
+[registry.md](registry.md).
+
 This workflow keeps the microservices independent while providing a clear path from development to production.
 \nFor monitoring instructions see [monitoring.md](monitoring.md).

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,34 @@
+# Docker Image Registry
+
+This project publishes container images for every microservice to **GitHub Container Registry (GHCR)**. Images are built automatically whenever the `main` branch is updated.
+
+## Images
+
+Each service folder under `services/` produces an image named:
+
+```
+ghcr.io/<owner>/<service>.api:latest
+```
+
+Where `<owner>` is your GitHub user or organisation and `<service>` matches the directory name (for example `Catalog`).
+
+## Building and Publishing
+
+The workflow defined in `.github/workflows/docker-images.yml` builds all services and pushes them to GHCR. It runs on every push to `main` and can also be triggered manually from the GitHub Actions tab.
+
+## Pulling Images Locally
+
+To use the published images on your machine:
+
+```bash
+docker login ghcr.io -u <user> -p <token>
+docker pull ghcr.io/<owner>/<service>.api:latest
+```
+
+The token requires the `read:packages` permission. Once the image is pulled you can run it directly or reference it in `docker-compose.yml` by setting the `REGISTRY` variable:
+
+```bash
+REGISTRY=ghcr.io/<owner>/ docker compose up <service>.api
+```
+
+This instructs Docker Compose to fetch the image from GHCR instead of building it locally.


### PR DESCRIPTION
## Summary
- add workflow to build and push each service image
- document registry usage
- mention registry documentation in the README and process guide

## Testing
- `docker compose -f docker-compose.tests.yml up --build --abort-on-container-exit` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688355d3f7d0832ebbcc7b1e73ce8f22