### PR TITLE
Improve validation and JWT auth

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -25,7 +25,7 @@ The repository already contains an **Auth** service based on Duende IdentityServ
 3. The frontend stores the tokens and includes the access token in the `Authorization: Bearer <token>` header.
 4. Configure the Kong gateway with the `jwt` or `openid-connect` plugin. The plugin verifies the signature using the Auth service's public key and rejects expired or malformed tokens.
    The plugin can point to the Auth service's JWKS endpoint so that signing keys
-   rotate automatically.
+   rotate automatically. Combine this with the `acl` plugin so that only members of the right groups can call sensitive endpoints.
 5. Remove the `key-auth` plugin from `kong.yml` and delete the `demo-token` login endpoint in `Security`.
 
 The Auth service should pull user records from the **User** service database. Extend the user table to include password hashes and roles. Use a strong hashing algorithm such as **BCrypt** or **scrypt**. Alternatively, point IdentityServer's user store directly at the User database. For production deployments consider a managed identity provider such as **Keycloak** or **Auth0** to reduce maintenance overhead.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -16,6 +16,8 @@ Where `<owner>` is your GitHub user or organisation and `<service>` matches the 
 
 The workflow defined in `.github/workflows/docker-images.yml` builds all services and pushes them to GHCR. It runs on every push to `main` and can also be triggered manually from the GitHub Actions tab.
 
+Each microservice has its own Dockerfile under `services/<ServiceName>`. The workflow loops over these directories and publishes an image per service. When you add new services simply create a Dockerfile and push the code – the pipeline will automatically build and tag `ghcr.io/<owner>/<service>.api:latest`.
+
 ## Pulling Images Locally
 
 To use the published images on your machine:

--- a/services/Admin/app/main.py
+++ b/services/Admin/app/main.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 import httpx
-from fastapi import FastAPI, HTTPException, Depends
+from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
@@ -44,19 +44,24 @@ async def get_client():
     async with httpx.AsyncClient() as client:
         yield client
 
+def verify_admin(request: Request):
+    groups = request.headers.get("X-Consumer-Groups", "")
+    if "admin-group" not in groups.split(","):
+        raise HTTPException(status_code=403, detail="forbidden")
+
 @app.get("/healthz")
 async def healthz():
     return {"status": "ok"}
 
 @app.get("/products")
-async def list_products(client: httpx.AsyncClient = Depends(get_client)):
+async def list_products(client: httpx.AsyncClient = Depends(get_client), _: None = Depends(verify_admin)):
     REQUEST_COUNTER.labels("list_products").inc()
     resp = await client.get(f"{CATALOG_URL}/products")
     resp.raise_for_status()
     return resp.json()
 
 @app.put("/products/{pid}")
-async def update_product(pid: str, payload: dict, client: httpx.AsyncClient = Depends(get_client)):
+async def update_product(pid: str, payload: dict, client: httpx.AsyncClient = Depends(get_client), _: None = Depends(verify_admin)):
     REQUEST_COUNTER.labels("update_product").inc()
     resp = await client.put(f"{CATALOG_URL}/products/{pid}", json=payload)
     if resp.status_code >= 400:
@@ -67,7 +72,7 @@ class AdjustQty(BaseModel):
     quantity: int
 
 @app.post("/products/{pid}/inventory")
-async def adjust_inventory(pid: str, body: AdjustQty, client: httpx.AsyncClient = Depends(get_client)):
+async def adjust_inventory(pid: str, body: AdjustQty, client: httpx.AsyncClient = Depends(get_client), _: None = Depends(verify_admin)):
     REQUEST_COUNTER.labels("adjust_inventory").inc()
     resp = await client.post(
         f"{INVENTORY_URL}/inventory/release",
@@ -78,14 +83,14 @@ async def adjust_inventory(pid: str, body: AdjustQty, client: httpx.AsyncClient 
     return resp.json()
 
 @app.get("/orders")
-async def list_orders(client: httpx.AsyncClient = Depends(get_client)):
+async def list_orders(client: httpx.AsyncClient = Depends(get_client), _: None = Depends(verify_admin)):
     REQUEST_COUNTER.labels("orders").inc()
     resp = await client.get(f"{ORDER_URL}/orders")
     resp.raise_for_status()
     return resp.json()
 
 @app.get("/users")
-async def list_users(client: httpx.AsyncClient = Depends(get_client)):
+async def list_users(client: httpx.AsyncClient = Depends(get_client), _: None = Depends(verify_admin)):
     REQUEST_COUNTER.labels("users").inc()
     resp = await client.get(f"{USER_URL}/users")
     resp.raise_for_status()

--- a/services/Admin/tests/test_admin.py
+++ b/services/Admin/tests/test_admin.py
@@ -1,10 +1,11 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from app.main import app
 
 @pytest.mark.asyncio
 async def test_healthz():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/healthz")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}

--- a/services/Cart/Controllers/CartController.cs
+++ b/services/Cart/Controllers/CartController.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Cart.Api.Domain;
 using Cart.Api.Infrastructure;
@@ -11,10 +13,13 @@ namespace Cart.Api.Controllers;
 
 [ApiController]
 [Route("cart/{userId}")]
-public class CartController(ICartStore store) : ControllerBase
+public class CartController(ICartStore store, IHttpClientFactory httpClientFactory) : ControllerBase
 {
     private static readonly Counter CheckoutCounter = Metrics.CreateCounter(
         "cart_checkout_total", "Total checkouts processed");
+    private readonly HttpClient inventoryClient = httpClientFactory.CreateClient("inventory");
+
+    private record StockResponse(int quantity);
 
     [HttpGet]
     public async Task<IList<CartItem>> Get(string userId)
@@ -25,14 +30,22 @@ public class CartController(ICartStore store) : ControllerBase
     [HttpPost("items")]
     public async Task<IActionResult> AddItem(string userId, [FromBody] ModifyItemDto dto)
     {
+        if (dto.Quantity < 1)
+            return BadRequest();
+        var stock = await inventoryClient.GetFromJsonAsync<StockResponse>($"/inventory/{dto.ProductId}") ?? new StockResponse(0);
+        var available = stock.quantity;
         var items = await store.GetCartAsync(userId);
         var existing = items.FirstOrDefault(i => i.ProductId == dto.ProductId);
         if (existing != null)
         {
+            if (existing.Quantity + dto.Quantity > available)
+                return BadRequest();
             existing.Quantity += dto.Quantity;
         }
         else
         {
+            if (dto.Quantity > available)
+                return BadRequest();
             items.Add(new CartItem { ProductId = dto.ProductId, Quantity = dto.Quantity });
         }
         await store.SetCartAsync(userId, items);
@@ -42,9 +55,14 @@ public class CartController(ICartStore store) : ControllerBase
     [HttpPut("items/{productId}")]
     public async Task<IActionResult> UpdateItem(string userId, Guid productId, [FromBody] ModifyItemDto dto)
     {
+        if (dto.Quantity < 1)
+            return BadRequest();
+        var stock = await inventoryClient.GetFromJsonAsync<StockResponse>($"/inventory/{productId}") ?? new StockResponse(0);
         var items = await store.GetCartAsync(userId);
         var item = items.FirstOrDefault(i => i.ProductId == productId);
         if (item == null) return NotFound();
+        if (dto.Quantity > stock.quantity)
+            return BadRequest();
         item.Quantity = dto.Quantity;
         await store.SetCartAsync(userId, items);
         return Ok();

--- a/services/Cart/Program.cs
+++ b/services/Cart/Program.cs
@@ -6,6 +6,7 @@ using Cart.Api.Infrastructure;
 using Prometheus;
 using Serilog;
 using Microsoft.AspNetCore.Hosting;
+using System;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,6 +30,8 @@ builder.Services.AddStackExchangeRedisCache(options =>
 });
 
 builder.Services.AddSingleton<ICartStore, RedisCartStore>();
+var inventoryUrl = builder.Configuration["INVENTORY_URL"] ?? "http://inventory.api:8000";
+builder.Services.AddHttpClient("inventory", client => client.BaseAddress = new Uri(inventoryUrl));
 
 builder.Services.AddHealthChecks();
 

--- a/services/Gateway/kong.yml
+++ b/services/Gateway/kong.yml
@@ -2,13 +2,15 @@
 _transform: true
 consumers:
   - username: frontend
-    keyauth_credentials:
-      - key: mytestkey123
+    jwt_secrets:
+      - key: frontend
+        secret: myfrontendsecret
     acls:
       - group: frontend-group
   - username: admin
-    keyauth_credentials:
-      - key: adminkey456
+    jwt_secrets:
+      - key: admin
+        secret: myadminsecret
     acls:
       - group: admin-group
   
@@ -129,7 +131,7 @@ plugins:
       headers: ["*"]
       exposed_headers: ["*"]
       credentials: true
-  - name: key-auth
+  - name: jwt
   - name: acl
     config:
       allow:

--- a/services/Inventory/app/main.py
+++ b/services/Inventory/app/main.py
@@ -53,6 +53,8 @@ def get_stock(product_id: str, db: Session = Depends(get_db)):
 
 @app.post("/inventory/reserve")
 def reserve_stock(update: StockUpdate, db: Session = Depends(get_db)):
+    if update.quantity <= 0:
+        raise HTTPException(status_code=400, detail="quantity must be positive")
     inv = db.get(Inventory, update.product_id)
     if inv is None:
         inv = Inventory(product_id=update.product_id, quantity=0)
@@ -69,6 +71,8 @@ def reserve_stock(update: StockUpdate, db: Session = Depends(get_db)):
 
 @app.post("/inventory/release")
 def release_stock(update: StockUpdate, db: Session = Depends(get_db)):
+    if update.quantity <= 0:
+        raise HTTPException(status_code=400, detail="quantity must be positive")
     inv = db.get(Inventory, update.product_id)
     if inv is None:
         inv = Inventory(product_id=update.product_id, quantity=0)

--- a/services/Inventory/tests/test_inventory.py
+++ b/services/Inventory/tests/test_inventory.py
@@ -32,3 +32,7 @@ def test_insufficient_counter():
     assert r.status_code == 400
     metrics = client.get('/metrics').text
     assert 'inventory_insufficient_total 1.0' in metrics
+
+def test_negative_quantity():
+    r = client.post('/inventory/release', json={'product_id': 'p', 'quantity': 0})
+    assert r.status_code == 400

--- a/services/Order/Controllers/OrdersController.cs
+++ b/services/Order/Controllers/OrdersController.cs
@@ -26,12 +26,17 @@ public class OrdersController(OrderDbContext db) : ControllerBase
         => await db.Orders.Include(o => o.Items).FirstOrDefaultAsync(o => o.Id == id)
             is { } order ? Ok(order) : NotFound();
 
-    public record CreateOrderDto(Guid UserId, List<CreateOrderItemDto> Items);
+    public record CreateOrderDto(Guid UserId, List<CreateOrderItemDto> Items, decimal Total);
     public record CreateOrderItemDto(string ProductName, decimal Price);
 
     [HttpPost]
     public async Task<ActionResult<Guid>> Create([FromBody] CreateOrderDto dto)
     {
+        var calculated = dto.Items.Sum(i => i.Price);
+        if (dto.Total != calculated)
+            return BadRequest();
+        if (dto.Items.Any(i => i.Price <= 0))
+            return BadRequest();
         var order = new OrderEntity { UserId = dto.UserId };
         foreach (var item in dto.Items)
         {

--- a/services/Order/openapi.yaml
+++ b/services/Order/openapi.yaml
@@ -66,9 +66,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CreateOrderItemDto'
+        total:
+          type: number
       required:
         - userId
         - items
+        - total
   CreateOrderItemDto:
     type: object
     properties:

--- a/services/Promotion/app/main.py
+++ b/services/Promotion/app/main.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
 from fastapi.responses import Response
@@ -33,6 +33,8 @@ coupons: List[Coupon] = []
 
 @app.post("/coupons")
 async def create_coupon(coupon: Coupon):
+    if coupon.discount < 0 or coupon.discount > 100:
+        raise HTTPException(status_code=400, detail="discount must be between 0 and 100")
     coupons.append(coupon)
     logger.info("created coupon", extra={"code": coupon.code})
     COUPON_COUNTER.inc()

--- a/services/Promotion/tests/test_api.py
+++ b/services/Promotion/tests/test_api.py
@@ -12,6 +12,9 @@ async def test_create_coupon():
         assert resp.status_code == 200
         assert resp.json()["status"] == "created"
 
+        resp = await ac.post("/coupons", json={"code": "BAD", "discount": 150})
+        assert resp.status_code == 400
+
         resp = await ac.get("/coupons")
         data = resp.json()
         assert any(c["code"] == "SAVE10" for c in data)


### PR DESCRIPTION
## Summary
- check positive inventory quantities and discount range
- enforce cart quantity against inventory
- verify order total from items
- add admin role checks and switch gateway to JWT auth
- document Docker builds and JWT/ACL setup

## Testing
- `PYTHONPATH=. pytest -q` for Inventory service
- `PYTHONPATH=. pytest -q` for Promotion service
- `PYTHONPATH=. pytest -q` for Admin service
- ❌ `docker compose -f docker-compose.tests.yml up --build --abort-on-container-exit` *(failed: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836d882f04832e95ef21593c48d111