### PR TITLE
Implement real OTP verification

### DIFF
--- a/services/Security/README.md
+++ b/services/Security/README.md
@@ -34,6 +34,8 @@ Endpoints cover authentication, order/payment risk checks, rate limiting and aud
 
 The `/audit` endpoint accepts JSON payloads describing user or admin actions. Entries are stored in `logs/audit.log` by the `AuditService` and can be forwarded to a central log stack such as ELK. Login attempts are automatically audited with action codes `login-success`, `login-invalid-otp` and `login-blocked`.
 
+The login endpoint verifies Time-based One Time Passwords (TOTP). A demo secret is configured for user `u` and tests compute the current code to authenticate. In production the secrets would be provided by the User service or an external provider.
+
 ## Metrics
 
 Prometheus metrics are exposed via the Spring Boot Actuator at [`/actuator/prometheus`](http://localhost:8082/actuator/prometheus). These include login counts and other JVM statistics for use in Grafana dashboards.

--- a/services/Security/src/main/java/com/example/security/controller/SecurityController.java
+++ b/services/Security/src/main/java/com/example/security/controller/SecurityController.java
@@ -2,6 +2,7 @@ package com.example.security.controller;
 
 import com.example.security.model.*;
 import com.example.security.service.AuditService;
+import com.example.security.service.OtpService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,10 +21,12 @@ public class SecurityController {
     private static final int MAX_FAILED_ATTEMPTS = 5;
     private final Map<String, Integer> attempts = new ConcurrentHashMap<>();
     private final AuditService auditService;
+    private final OtpService otpService;
     private final Counter riskBlocks;
 
-    public SecurityController(AuditService auditService, MeterRegistry registry) {
+    public SecurityController(AuditService auditService, OtpService otpService, MeterRegistry registry) {
         this.auditService = auditService;
+        this.otpService = otpService;
         this.riskBlocks = Counter.builder("security_risk_blocks_total")
                 .description("Number of requests blocked by risk check")
                 .register(registry);
@@ -32,19 +35,19 @@ public class SecurityController {
     @PostMapping("/auth/login")
     public TokenResponse login(@RequestBody LoginRequest req, HttpServletRequest http) {
         String ip = http.getRemoteAddr();
-        int failCount = attempts.getOrDefault(ip, 0);
+        int failCount = attempts.getOrDefault(req.username(), 0);
         if (failCount >= MAX_FAILED_ATTEMPTS) {
-            log.warn("blocked login from {}", ip);
+            log.warn("blocked login for user {} from {}", req.username(), ip);
             auditService.record(new AuditLog(req.username(), "login-blocked", "ip=" + ip));
             return new TokenResponse("blocked");
         }
-        if (req.otp() == null || !req.otp().matches("\\d{6}")) {
+        if (!otpService.verify(req.username(), req.otp())) {
             log.warn("invalid otp from {} for user {}", ip, req.username());
-            attempts.put(ip, failCount + 1);
+            attempts.put(req.username(), failCount + 1);
             auditService.record(new AuditLog(req.username(), "login-invalid-otp", "ip=" + ip));
             return new TokenResponse("invalid-otp");
         }
-        attempts.remove(ip);
+        attempts.remove(req.username());
         log.info("successful login for user {} from {}", req.username(), ip);
         auditService.record(new AuditLog(req.username(), "login-success", "ip=" + ip));
         return new TokenResponse("demo-token");

--- a/services/Security/src/main/java/com/example/security/service/OtpService.java
+++ b/services/Security/src/main/java/com/example/security/service/OtpService.java
@@ -1,0 +1,77 @@
+package com.example.security.service;
+
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class OtpService {
+    private static final Duration STEP = Duration.ofSeconds(30);
+    private static final String DEMO_SECRET = "JBSWY3DPEHPK3PXP";
+    private final Map<String, byte[]> secrets = new ConcurrentHashMap<>();
+
+    public OtpService() {
+        // In production secrets would come from the User service
+        secrets.put("u", decodeBase32(DEMO_SECRET));
+    }
+
+    public boolean verify(String username, String otp) {
+        if (otp == null) {
+            return false;
+        }
+        byte[] key = secrets.get(username);
+        if (key == null) {
+            return false;
+        }
+        int expected;
+        try {
+            expected = generateTotp(key, Instant.now());
+        } catch (GeneralSecurityException e) {
+            return false;
+        }
+        return String.format("%06d", expected).equals(otp);
+    }
+
+    private int generateTotp(byte[] key, Instant timestamp) throws GeneralSecurityException {
+        long counter = timestamp.getEpochSecond() / STEP.getSeconds();
+        byte[] data = ByteBuffer.allocate(8).putLong(counter).array();
+        Mac mac = Mac.getInstance("HmacSHA1");
+        mac.init(new SecretKeySpec(key, "HmacSHA1"));
+        byte[] hash = mac.doFinal(data);
+        int offset = hash[hash.length - 1] & 0xF;
+        int binary = ((hash[offset] & 0x7F) << 24)
+                | ((hash[offset + 1] & 0xFF) << 16)
+                | ((hash[offset + 2] & 0xFF) << 8)
+                | (hash[offset + 3] & 0xFF);
+        return binary % 1_000_000;
+    }
+
+    private byte[] decodeBase32(String str) {
+        String base32 = str.replace("=", "").toUpperCase();
+        int buffer = 0, bitsLeft = 0, index = 0;
+        byte[] result = new byte[base32.length() * 5 / 8];
+        for (char c : base32.toCharArray()) {
+            int val = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".indexOf(c);
+            if (val < 0) continue;
+            buffer = (buffer << 5) | val;
+            bitsLeft += 5;
+            if (bitsLeft >= 8) {
+                result[index++] = (byte) ((buffer >> (bitsLeft - 8)) & 0xFF);
+                bitsLeft -= 8;
+            }
+        }
+        if (index != result.length) {
+            byte[] tmp = new byte[index];
+            System.arraycopy(result, 0, tmp, 0, index);
+            return tmp;
+        }
+        return result;
+    }
+}

--- a/services/Security/src/test/java/com/example/security/controller/LoginControllerTests.java
+++ b/services/Security/src/test/java/com/example/security/controller/LoginControllerTests.java
@@ -2,6 +2,10 @@ package com.example.security.controller;
 
 import com.example.security.model.AuditLog;
 import com.example.security.service.AuditService;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -33,9 +37,11 @@ public class LoginControllerTests {
 
     @Test
     void auditRecordedOnSuccess() throws Exception {
+        String otp = generateOtp();
+
         mvc.perform(post("/auth/login")
                 .contentType("application/json")
-                .content("{\"username\":\"u\",\"password\":\"p\",\"otp\":\"123456\"}"))
+                .content("{\"username\":\"u\",\"password\":\"p\",\"otp\":\"" + otp + "\"}"))
             .andExpect(status().isOk())
             .andExpect(content().string("{\"token\":\"demo-token\"}"));
 
@@ -50,6 +56,41 @@ public class LoginControllerTests {
             .andExpect(status().isAccepted());
 
         assertEquals(1, auditService.getEntries().size());
+    }
+
+    private String generateOtp() throws Exception {
+        byte[] key = decodeBase32("JBSWY3DPEHPK3PXP");
+        long counter = Instant.now().getEpochSecond() / 30;
+        byte[] data = ByteBuffer.allocate(8).putLong(counter).array();
+        Mac mac = Mac.getInstance("HmacSHA1");
+        mac.init(new SecretKeySpec(key, "HmacSHA1"));
+        byte[] hash = mac.doFinal(data);
+        int offset = hash[hash.length - 1] & 0xF;
+        int binary = ((hash[offset] & 0x7F) << 24) |
+                ((hash[offset + 1] & 0xFF) << 16) |
+                ((hash[offset + 2] & 0xFF) << 8) |
+                (hash[offset + 3] & 0xFF);
+        int otp = binary % 1_000_000;
+        return String.format("%06d", otp);
+    }
+
+    private byte[] decodeBase32(String str) {
+        String base32 = str.replace("=", "").toUpperCase();
+        int buffer = 0, bitsLeft = 0, index = 0;
+        byte[] result = new byte[base32.length() * 5 / 8];
+        for (char c : base32.toCharArray()) {
+            int val = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".indexOf(c);
+            if (val < 0) continue;
+            buffer = (buffer << 5) | val;
+            bitsLeft += 5;
+            if (bitsLeft >= 8) {
+                result[index++] = (byte) ((buffer >> (bitsLeft - 8)) & 0xFF);
+                bitsLeft -= 8;
+            }
+        }
+        byte[] out = new byte[index];
+        System.arraycopy(result, 0, out, 0, index);
+        return out;
     }
 }
 


### PR DESCRIPTION
## Summary
- add internal TOTP verification service
- check OTP and failed logins per user
- adapt tests to compute real OTP codes
- document the TOTP behaviour

## Testing
- `poetry run pytest -q` for Admin, Analytics, and Inventory
- `dotnet test` for Auth, Cart, Catalog, Order, Shipping and User
- `npm install --legacy-peer-deps && npm test --silent`
- `./services/Security/gradlew -p services/Security test`

------
https://chatgpt.com/codex/tasks/task_e_688370ed58dc832ea55ae9ed374b246f