### PR TITLE
Add CI image build info and unify Inventory logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains microservices that together form a small e-commerce pla
   - **User** – manages user accounts under `services/User`.
   - **Shipping** – coordinates delivery under `services/Shipping`.
   - **Payment** – processes transactions under `services/Payment`.
-  - **Inventory** – manages stock levels under `services/Inventory`.
+  - **Inventory** – manages stock levels under `services/Inventory` and logs in JSON using structlog.
   - **Analytics** – collects metrics under `services/Analytics`.
   - **Admin** – backoffice APIs under `services/Admin`.
   - **Auth** – provides authentication under `services/Auth`.
@@ -58,6 +58,15 @@ them to a registry. For example the CI pipeline uses
 `REGISTRY=ghcr.io/<owner>/` so images are pushed to GitHub Container Registry.
 When using the Security service, the Gradle wrapper JAR is downloaded
 automatically on first run. Simply execute `./gradlew` in `services/Security`.
+
+### Automated Docker Builds
+
+Every push to the `main` branch triggers the
+`docker-images.yml` workflow which builds a container image for each service and
+publishes it to GitHub Container Registry.  See
+[docs/registry.md](docs/registry.md) for details on the image names and how to
+pull them locally. This allows you to run the stack using remote images instead
+of building them on your machine.
 
 ## Service Documentation
 

--- a/services/Inventory/app/main.py
+++ b/services/Inventory/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-import logging, json
+import structlog
 from prometheus_client import Counter, Gauge, generate_latest, CONTENT_TYPE_LATEST
 from fastapi.responses import Response
 
@@ -9,8 +9,8 @@ from .db import SessionLocal, init_db
 from .models import Inventory
 
 app = FastAPI(title="Inventory API", version="v1")
-logging.basicConfig(format='%(message)s', level=logging.INFO)
-logger = logging.getLogger("inventory")
+structlog.configure(processors=[structlog.processors.JSONRenderer()])
+logger = structlog.get_logger("inventory")
 
 STOCK_COUNTER = Counter("inventory_updates_total", "Inventory updates", ["action"])
 INSUFFICIENT_COUNTER = Counter(
@@ -66,7 +66,7 @@ def reserve_stock(update: StockUpdate, db: Session = Depends(get_db)):
     db.commit()
     STOCK_COUNTER.labels("reserve").inc()
     LOW_GAUGE.labels(inv.product_id).set(inv.quantity)
-    logger.info(json.dumps({"action": "reserve", "product_id": inv.product_id, "quantity": inv.quantity}))
+    logger.info("reserve", product_id=inv.product_id, quantity=inv.quantity)
     return {"reserved": update.quantity}
 
 @app.post("/inventory/release")
@@ -81,7 +81,7 @@ def release_stock(update: StockUpdate, db: Session = Depends(get_db)):
     db.commit()
     STOCK_COUNTER.labels("release").inc()
     LOW_GAUGE.labels(inv.product_id).set(inv.quantity)
-    logger.info(json.dumps({"action": "release", "product_id": inv.product_id, "quantity": inv.quantity}))
+    logger.info("release", product_id=inv.product_id, quantity=inv.quantity)
     return {"released": update.quantity}
 
 @app.get("/metrics")

--- a/services/Inventory/poetry.lock
+++ b/services/Inventory/poetry.lock
@@ -669,6 +669,24 @@ anyio = ">=3.4.0,<5"
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
 
 [[package]]
+name = "structlog"
+version = "24.4.0"
+description = "Structured Logging for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "structlog-24.4.0-py3-none-any.whl", hash = "sha256:597f61e80a91cc0749a9fd2a098ed76715a1c8a01f73e336b746504d1aad7610"},
+    {file = "structlog-24.4.0.tar.gz", hash = "sha256:b27bfecede327a6d2da5fbc96bd859f114ecc398a6389d664f62085ee7ae6fc4"},
+]
+
+[package.extras]
+dev = ["freezegun (>=0.2.8)", "mypy (>=1.4)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "rich", "simplejson", "twisted"]
+docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "sphinxext-opengraph", "twisted"]
+tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
+typing = ["mypy (>=1.4)", "rich", "twisted"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.14.1"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -717,4 +735,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.5.0)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "0508937e8b0bc06c3d544694212dab816e7a7a061babcee6a6893eee4646b365"
+content-hash = "2cf836168a5d65bf90774e3c85fb1694bdb1f3af577046097240ea46e67a7946"

--- a/services/Inventory/pyproject.toml
+++ b/services/Inventory/pyproject.toml
@@ -13,6 +13,7 @@ SQLAlchemy = "^2.0.29"
 psycopg2-binary = "^2.9.9"
 prometheus-client = "^0.20.0"
 httpx = "^0.27.2"
+structlog = "^24.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.1.1"


### PR DESCRIPTION
## Summary
- document automatic Docker image builds in the README
- switch Inventory service logging to structlog JSON output

## Testing
- `poetry install -n`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837c489c44832e9bf61c860f221630