### PR TITLE
Improve container workflow and clean security API

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'services/**/Dockerfile'
+      - 'frontend/Dockerfile'
       - '.github/workflows/docker-images.yml'
   workflow_dispatch:
 
@@ -16,7 +17,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        service: [Admin, Analytics, Auth, Cart, Catalog, Gateway, Inventory, Notification, Order, Payment, Promotion, Recommendation, Review, Security, Shipping, User]
+        service: [Admin, Analytics, Auth, Cart, Catalog, Gateway, Inventory, Notification, Order, Payment, Promotion, Recommendation, Review, Security, Shipping, User, Frontend]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -28,8 +29,16 @@ jobs:
       - name: Build and push
         run: |
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t ghcr.io/$owner/${{ matrix.service }}.api:latest \
-            --push \
-            -f services/${{ matrix.service }}/Dockerfile services/${{ matrix.service }}
+          if [ "${{ matrix.service }}" = "Frontend" ]; then
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              -t ghcr.io/$owner/frontend.app:latest \
+              --push \
+              -f frontend/Dockerfile frontend
+          else
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              -t ghcr.io/$owner/${{ matrix.service }}.api:latest \
+              --push \
+              -f services/${{ matrix.service }}/Dockerfile services/${{ matrix.service }}
+          fi

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ automatically on first run. Simply execute `./gradlew` in `services/Security`.
 
 Every push to the `main` branch triggers the
 `docker-images.yml` workflow which builds a container image for each service and
-publishes it to GitHub Container Registry.  See
+the frontend, then publishes them to GitHub Container Registry.  See
 [docs/registry.md](docs/registry.md) for details on the image names and how to
 pull them locally. This allows you to run the stack using remote images instead
 of building them on your machine.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,6 +1,6 @@
 # Docker Image Registry
 
-This project publishes container images for every microservice to **GitHub Container Registry (GHCR)**. Images are built automatically whenever the `main` branch is updated.
+This project publishes container images for every microservice and the frontend to **GitHub Container Registry (GHCR)**. Images are built automatically whenever the `main` branch is updated.
 
 ## Images
 
@@ -11,6 +11,12 @@ ghcr.io/<owner>/<service>.api:latest
 ```
 
 Where `<owner>` is your GitHub user or organisation and `<service>` matches the directory name (for example `Catalog`).
+
+The frontend image is built from the `frontend` directory as:
+
+```
+ghcr.io/<owner>/frontend.app:latest
+```
 
 ## Building and Publishing
 

--- a/services/Security/Minimum.md
+++ b/services/Security/Minimum.md
@@ -16,7 +16,6 @@ This document lists the minimal information required to integrate with the Secur
 - `POST /auth/login` – obtain authentication token
 - `POST /risk/order-check` – order risk check
 - `POST /risk/payment-check` – payment risk check
-- `POST /rate-limit` – rate limiting check
 - `POST /audit` – submit audit log
 
 Refer to `openapi.yaml` for full schema details.

--- a/services/Security/README.md
+++ b/services/Security/README.md
@@ -28,7 +28,7 @@ Uses PostgreSQL schema `security` in the shared instance. Configure the datasour
 
 ## API Contract
 
-Endpoints cover authentication, order/payment risk checks, rate limiting and audit logging. The REST API is documented in [openapi.yaml](openapi.yaml).
+Endpoints cover authentication, order/payment risk checks and audit logging. The REST API is documented in [openapi.yaml](openapi.yaml).
 
 ## Audit Logs
 

--- a/services/Security/openapi.yaml
+++ b/services/Security/openapi.yaml
@@ -51,22 +51,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RiskCheckResponse'
-  /rate-limit:
-    post:
-      summary: Rate limit check
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RateLimitRequest'
-      responses:
-        '200':
-          description: result
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RateLimitResponse'
   /audit:
     post:
       summary: Audit log
@@ -109,18 +93,6 @@ components:
           type: boolean
         reason:
           type: string
-    RateLimitRequest:
-      type: object
-      properties:
-        userId:
-          type: string
-        action:
-          type: string
-    RateLimitResponse:
-      type: object
-      properties:
-        allowed:
-          type: boolean
     AuditLog:
       type: object
       properties:

--- a/services/Security/src/main/java/com/example/security/controller/SecurityController.java
+++ b/services/Security/src/main/java/com/example/security/controller/SecurityController.java
@@ -75,11 +75,6 @@ public class SecurityController {
         return new RiskCheckResponse(true, "");
     }
 
-    @PostMapping("/rate-limit")
-    public RateLimitResponse rateLimit(@RequestBody RateLimitRequest req) {
-        return new RateLimitResponse(true);
-    }
-
     @PostMapping("/audit")
     public void audit(@RequestBody AuditLog req) {
         auditService.record(req);

--- a/services/Security/src/main/java/com/example/security/model/RateLimitRequest.java
+++ b/services/Security/src/main/java/com/example/security/model/RateLimitRequest.java
@@ -1,4 +1,0 @@
-package com.example.security.model;
-
-public record RateLimitRequest(String userId, String action) {}
-

--- a/services/Security/src/main/java/com/example/security/model/RateLimitResponse.java
+++ b/services/Security/src/main/java/com/example/security/model/RateLimitResponse.java
@@ -1,4 +1,0 @@
-package com.example.security.model;
-
-public record RateLimitResponse(boolean allowed) {}
-


### PR DESCRIPTION
## Summary
- publish a frontend Docker image from GitHub Actions
- remove the unused Security `/rate-limit` endpoint and schemas
- update docs and README for the new image and API cleanup

## Testing
- `./gradlew test` in Security service
- `poetry run pytest` for Admin, Analytics, Inventory, Promotion and Review
- `npm test --silent` in frontend
- ❌ `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688388d0bd14832e88f7d38158bfec07