### PR TITLE
Add tests for new microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ This repository contains microservices that together form a small e-commerce pla
   - **Attribute** – manages product attributes under `services/Attribute`.
   - **Asset** – stores media assets under `services/Asset`.
   - **Seo** – generates sitemaps under `services/Seo`.
+  - **RMA** – handles returns and refunds under `services/Rma`.
+  - **Tax** – calculates duties and tax under `services/Tax`.
+  - **Currency** – provides exchange rates under `services/Currency`.
+  - **Address** – offers address validation under `services/Address`.
+  - **ShippingRate** – aggregates shipping quotes under `services/ShippingRate`.
 
 ## Gateway
 

--- a/services/Address/Dockerfile
+++ b/services/Address/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir poetry
+WORKDIR /app
+COPY pyproject.toml ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi --no-root
+COPY ./app ./app
+RUN poetry install --no-interaction --no-ansi
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Address/README.md
+++ b/services/Address/README.md
@@ -1,0 +1,3 @@
+# Address Service
+
+Simple address validation and geocoding endpoints.

--- a/services/Address/app/main.py
+++ b/services/Address/app/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from fastapi.responses import Response
+
+app = FastAPI(title="Address API", version="v1")
+
+VALIDATION_COUNTER = Counter("address_validations_total", "Address validations")
+
+@app.get("/validate")
+def validate(address: str):
+    VALIDATION_COUNTER.inc()
+    return {"address": address, "valid": True}
+
+@app.get("/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/Address/docker-compose.yml
+++ b/services/Address/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  address.api:
+    build: .
+    image: address.api:dev
+    container_name: address-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9030:8000"

--- a/services/Address/openapi.yaml
+++ b/services/Address/openapi.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Address API
+  version: v1
+paths:
+  /validate:
+    get:
+      summary: Validate address
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+components: {}

--- a/services/Address/pyproject.toml
+++ b/services/Address/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "address"
+version = "0.1.0"
+description = "Address and Geo Service"
+authors = ["E-Commerce Team"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+prometheus-client = "^0.20"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/Address/tests/test_address.py
+++ b/services/Address/tests/test_address.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_validate():
+    resp = client.get('/validate', params={'address': '123 Main St'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['address'] == '123 Main St'
+    assert data['valid'] is True

--- a/services/Currency/Dockerfile
+++ b/services/Currency/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir poetry
+WORKDIR /app
+COPY pyproject.toml ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi --no-root
+COPY ./app ./app
+RUN poetry install --no-interaction --no-ansi
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Currency/README.md
+++ b/services/Currency/README.md
@@ -1,0 +1,3 @@
+# Currency Service
+
+Offers exchange rates and localisation helpers.

--- a/services/Currency/app/main.py
+++ b/services/Currency/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from fastapi.responses import Response
+
+app = FastAPI(title="Currency API", version="v1")
+
+FX_COUNTER = Counter("fx_requests_total", "FX rate lookups")
+
+RATES = {"USD": 1.0, "EUR": 0.92, "JPY": 157.5}
+
+@app.get("/rate/{currency}")
+def get_rate(currency: str):
+    FX_COUNTER.inc()
+    return {"currency": currency, "rate": RATES.get(currency.upper(), 1.0)}
+
+@app.get("/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/Currency/docker-compose.yml
+++ b/services/Currency/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  currency.api:
+    build: .
+    image: currency.api:dev
+    container_name: currency-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9020:8000"

--- a/services/Currency/openapi.yaml
+++ b/services/Currency/openapi.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Currency API
+  version: v1
+paths:
+  /rate/{currency}:
+    get:
+      summary: Get exchange rate
+      parameters:
+        - in: path
+          name: currency
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+components: {}

--- a/services/Currency/pyproject.toml
+++ b/services/Currency/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "currency"
+version = "0.1.0"
+description = "Multi-currency and internationalisation"
+authors = ["E-Commerce Team"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+prometheus-client = "^0.20"
+httpx = "^0.27"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/Currency/tests/test_currency.py
+++ b/services/Currency/tests/test_currency.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_rate():
+    resp = client.get('/rate/USD')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['currency'] == 'USD'
+    assert isinstance(data['rate'], float)

--- a/services/Gateway/kong.yml
+++ b/services/Gateway/kong.yml
@@ -118,6 +118,45 @@ services:
         paths:
           - /api/v1/cms
         strip_path: true
+  - name: rma
+    url: http://rma.api:8000
+    routes:
+      - name: rma
+        paths:
+          - /api/v1/rma
+        strip_path: true
+
+  - name: tax
+    url: http://tax.api:8000
+    routes:
+      - name: tax
+        paths:
+          - /api/v1/tax
+        strip_path: true
+
+  - name: currency
+    url: http://currency.api:8000
+    routes:
+      - name: currency
+        paths:
+          - /api/v1/currency
+        strip_path: true
+
+  - name: address
+    url: http://address.api:8000
+    routes:
+      - name: address
+        paths:
+          - /api/v1/address
+        strip_path: true
+
+  - name: shippingrate
+    url: http://shippingrate.api:8000
+    routes:
+      - name: shippingrate
+        paths:
+          - /api/v1/shippingrate
+        strip_path: true
 
   - name: auth
     url: http://auth.api:80

--- a/services/Rma/Dockerfile
+++ b/services/Rma/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir poetry
+WORKDIR /app
+COPY pyproject.toml ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi --no-root
+COPY ./app ./app
+RUN poetry install --no-interaction --no-ansi
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Rma/README.md
+++ b/services/Rma/README.md
@@ -1,0 +1,3 @@
+# RMA Service
+
+Handles return merchandise authorisation and refunds.

--- a/services/Rma/app/main.py
+++ b/services/Rma/app/main.py
@@ -1,0 +1,37 @@
+from enum import Enum
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from fastapi.responses import Response
+
+class Status(str, Enum):
+    requested = "requested"
+    approved = "approved"
+    shipped = "shipped"
+    received = "received"
+    refunded = "refunded"
+
+class ReturnRequest(BaseModel):
+    order_id: str
+    reason: str
+
+app = FastAPI(title="RMA API", version="v1")
+
+RETURNS = {}
+REQUEST_COUNTER = Counter("rma_requests_total", "Return requests")
+
+@app.post("/returns/{rma_id}")
+def create_return(rma_id: str, req: ReturnRequest):
+    RETURNS[rma_id] = {"status": Status.requested, "order_id": req.order_id, "reason": req.reason}
+    REQUEST_COUNTER.inc()
+    return {"rma_id": rma_id}
+
+@app.get("/returns/{rma_id}")
+def get_return(rma_id: str):
+    if rma_id not in RETURNS:
+        raise HTTPException(status_code=404, detail="not found")
+    return RETURNS[rma_id]
+
+@app.get("/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/Rma/docker-compose.yml
+++ b/services/Rma/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  rma.api:
+    build: .
+    image: rma.api:dev
+    container_name: rma-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9000:8000"

--- a/services/Rma/openapi.yaml
+++ b/services/Rma/openapi.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  title: RMA API
+  version: v1
+paths:
+  /returns/{id}:
+    post:
+      summary: Create return request
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReturnRequest'
+      responses:
+        '200':
+          description: Created
+    get:
+      summary: Get return status
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    ReturnRequest:
+      type: object
+      properties:
+        order_id:
+          type: string
+        reason:
+          type: string
+      required:
+        - order_id
+        - reason

--- a/services/Rma/pyproject.toml
+++ b/services/Rma/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "rma"
+version = "0.1.0"
+description = "Return and Refund Service"
+authors = ["E-Commerce Team"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+prometheus-client = "^0.20"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/Rma/tests/test_rma.py
+++ b/services/Rma/tests/test_rma.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_create_and_get_return():
+    resp = client.post('/returns/1', json={'order_id': 'o123', 'reason': 'damaged'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['rma_id'] == '1'
+
+    resp = client.get('/returns/1')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['status'] == 'requested'
+    assert data['order_id'] == 'o123'

--- a/services/ShippingRate/Dockerfile
+++ b/services/ShippingRate/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir poetry
+WORKDIR /app
+COPY pyproject.toml ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi --no-root
+COPY ./app ./app
+RUN poetry install --no-interaction --no-ansi
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/ShippingRate/README.md
+++ b/services/ShippingRate/README.md
@@ -1,0 +1,3 @@
+# Shipping Rate Aggregator Service
+
+Aggregates quotes from multiple shipping providers.

--- a/services/ShippingRate/app/main.py
+++ b/services/ShippingRate/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from fastapi.responses import Response
+
+app = FastAPI(title="Shipping Rate API", version="v1")
+
+QUOTE_COUNTER = Counter("quote_requests_total", "Shipping quote requests")
+
+@app.post("/rates")
+def get_rate(weight: float):
+    QUOTE_COUNTER.inc()
+    price = round(5 + weight * 0.5, 2)
+    return {"price": price}
+
+@app.get("/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/ShippingRate/docker-compose.yml
+++ b/services/ShippingRate/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  shippingrate.api:
+    build: .
+    image: shippingrate.api:dev
+    container_name: shippingrate-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9040:8000"

--- a/services/ShippingRate/openapi.yaml
+++ b/services/ShippingRate/openapi.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Shipping Rate API
+  version: v1
+paths:
+  /rates:
+    post:
+      summary: Get shipping rate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                weight:
+                  type: number
+      responses:
+        '200':
+          description: OK
+components: {}

--- a/services/ShippingRate/pyproject.toml
+++ b/services/ShippingRate/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "shippingrate"
+version = "0.1.0"
+description = "Shipping Rate Aggregator"
+authors = ["E-Commerce Team"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+prometheus-client = "^0.20"
+httpx = "^0.27"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/ShippingRate/tests/test_shippingrate.py
+++ b/services/ShippingRate/tests/test_shippingrate.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_rate():
+    resp = client.post('/rates', json={'weight': 2.0})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'price' in data
+    assert data['price'] == round(5 + 2.0 * 0.5, 2)

--- a/services/Tax/Dockerfile
+++ b/services/Tax/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir poetry
+WORKDIR /app
+COPY pyproject.toml ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi --no-root
+COPY ./app ./app
+RUN poetry install --no-interaction --no-ansi
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Tax/README.md
+++ b/services/Tax/README.md
@@ -1,0 +1,3 @@
+# Tax Service
+
+Provides basic tax rate information and invoice generation.

--- a/services/Tax/app/main.py
+++ b/services/Tax/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from fastapi.responses import Response
+
+app = FastAPI(title="Tax API", version="v1")
+
+RATE_COUNTER = Counter("tax_requests_total", "Tax calculations")
+
+RATES = {"US": 0.07, "DE": 0.19, "UK": 0.20}
+
+@app.get("/rates/{country}")
+def get_rate(country: str):
+    RATE_COUNTER.inc()
+    return {"country": country, "rate": RATES.get(country.upper(), 0)}
+
+@app.get("/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/Tax/docker-compose.yml
+++ b/services/Tax/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  tax.api:
+    build: .
+    image: tax.api:dev
+    container_name: tax-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9010:8000"

--- a/services/Tax/openapi.yaml
+++ b/services/Tax/openapi.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Tax API
+  version: v1
+paths:
+  /rates/{country}:
+    get:
+      summary: Get tax rate
+      parameters:
+        - in: path
+          name: country
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+components: {}

--- a/services/Tax/pyproject.toml
+++ b/services/Tax/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "tax"
+version = "0.1.0"
+description = "Tax and Compliance Service"
+authors = ["E-Commerce Team"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+prometheus-client = "^0.20"
+httpx = "^0.27"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/Tax/tests/test_tax.py
+++ b/services/Tax/tests/test_tax.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_rate():
+    resp = client.get('/rates/US')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['country'] == 'US'
+    assert isinstance(data['rate'], float)

--- a/services/docker-compose.tests.yml
+++ b/services/docker-compose.tests.yml
@@ -79,6 +79,46 @@ services:
     command: >-
       bash -c "pip install --no-cache-dir poetry && poetry install && PYTHONPATH=. pytest -q"
 
+  rma.tests:
+    image: python:3.12-slim
+    working_dir: /workspace/services/Rma
+    volumes:
+      - ..:/workspace
+    command: >-
+      bash -c "pip install --no-cache-dir poetry && poetry install && PYTHONPATH=. pytest -q"
+
+  tax.tests:
+    image: python:3.12-slim
+    working_dir: /workspace/services/Tax
+    volumes:
+      - ..:/workspace
+    command: >-
+      bash -c "pip install --no-cache-dir poetry && poetry install && PYTHONPATH=. pytest -q"
+
+  currency.tests:
+    image: python:3.12-slim
+    working_dir: /workspace/services/Currency
+    volumes:
+      - ..:/workspace
+    command: >-
+      bash -c "pip install --no-cache-dir poetry && poetry install && PYTHONPATH=. pytest -q"
+
+  address.tests:
+    image: python:3.12-slim
+    working_dir: /workspace/services/Address
+    volumes:
+      - ..:/workspace
+    command: >-
+      bash -c "pip install --no-cache-dir poetry && poetry install && PYTHONPATH=. pytest -q"
+
+  shippingrate.tests:
+    image: python:3.12-slim
+    working_dir: /workspace/services/ShippingRate
+    volumes:
+      - ..:/workspace
+    command: >-
+      bash -c "pip install --no-cache-dir poetry && poetry install && PYTHONPATH=. pytest -q"
+
   frontend.tests:
     image: node:20
     working_dir: /workspace/frontend

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -254,6 +254,66 @@ services:
     ports:
       - "8900:8000"
 
+  rma.api:
+    build:
+      context: ./Rma
+      dockerfile: Dockerfile
+    image: ${REGISTRY}rma.api:dev
+    container_name: rma-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9000:8000"
+
+  tax.api:
+    build:
+      context: ./Tax
+      dockerfile: Dockerfile
+    image: ${REGISTRY}tax.api:dev
+    container_name: tax-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9010:8000"
+
+  currency.api:
+    build:
+      context: ./Currency
+      dockerfile: Dockerfile
+    image: ${REGISTRY}currency.api:dev
+    container_name: currency-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9020:8000"
+
+  address.api:
+    build:
+      context: ./Address
+      dockerfile: Dockerfile
+    image: ${REGISTRY}address.api:dev
+    container_name: address-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9030:8000"
+
+  shippingrate.api:
+    build:
+      context: ./ShippingRate
+      dockerfile: Dockerfile
+    image: ${REGISTRY}shippingrate.api:dev
+    container_name: shippingrate-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9040:8000"
+
   admin.api:
     build:
       context: ./Admin
@@ -298,6 +358,11 @@ services:
       - wishlist.api
       - experiment.api
       - cms.api
+      - rma.api
+      - tax.api
+      - currency.api
+      - address.api
+      - shippingrate.api
     ports:
       - "8000:8000"
       - "8443:8443"


### PR DESCRIPTION
## Summary
- add basic test suites for Address, Currency, RMA, Tax and ShippingRate services
- run these tests through docker-compose.tests.yml

## Testing
- `docker-compose -f services/docker-compose.tests.yml up --build --abort-on-container-exit` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6883935b531c832e9fe895ee1ead26d6