### PR TITLE
Add payment gateway, fraud detection and consent services

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This repository contains microservices that together form a small e-commerce pla
   - **User** – manages user accounts under `services/User`.
   - **Shipping** – coordinates delivery under `services/Shipping`.
   - **Payment** – processes transactions under `services/Payment`.
+  - **PaymentGateway** – routes third-party payments under `services/PaymentGateway`.
+  - **FraudDetection** – detects suspicious orders under `services/FraudDetection`.
+  - **Consent** – manages user privacy consent under `services/Consent`.
   - **Inventory** – manages stock levels under `services/Inventory` and logs in JSON using structlog.
   - **Analytics** – collects metrics under `services/Analytics`.
   - **Admin** – backoffice APIs under `services/Admin`.

--- a/services/Consent/Dockerfile
+++ b/services/Consent/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
+        --default-timeout=120 poetry && \
+    poetry config virtualenvs.create false && \
+    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
+    poetry install --no-interaction --no-ansi --no-root
+COPY app ./app
+RUN poetry install --no-interaction --no-ansi
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Consent/README.md
+++ b/services/Consent/README.md
@@ -1,0 +1,14 @@
+# Consent and Privacy Service
+
+Manages user consent records to support GDPR/CCPA requirements.
+
+## Development
+```bash
+poetry install
+poetry run uvicorn app.main:app --reload
+```
+
+## Docker
+```bash
+docker compose up --build
+```

--- a/services/Consent/app/main.py
+++ b/services/Consent/app/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Consent Service API", version="v1")
+
+class ConsentRecord(BaseModel):
+    user_id: str
+    accepted: bool
+
+consent_db = {}
+
+@app.post("/consent")
+async def set_consent(record: ConsentRecord):
+    consent_db[record.user_id] = record.accepted
+    return {"ok": True}
+
+@app.get("/consent/{user_id}")
+async def get_consent(user_id: str):
+    return {"user_id": user_id, "accepted": consent_db.get(user_id, False)}
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}

--- a/services/Consent/pyproject.toml
+++ b/services/Consent/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "consent"
+version = "0.1.0"
+description = "Consent and Privacy service"
+authors = ["Example <example@example.com>"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+pytest-asyncio = "^0.23"
+httpx = "^0.27"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/FraudDetection/Dockerfile
+++ b/services/FraudDetection/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
+        --default-timeout=120 poetry && \
+    poetry config virtualenvs.create false && \
+    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
+    poetry install --no-interaction --no-ansi --no-root
+COPY app ./app
+RUN poetry install --no-interaction --no-ansi
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/FraudDetection/README.md
+++ b/services/FraudDetection/README.md
@@ -1,0 +1,14 @@
+# Fraud Detection Service
+
+Example service performing simple rule-based fraud checks. Monitors IP and device fingerprints.
+
+## Development
+```bash
+poetry install
+poetry run uvicorn app.main:app --reload
+```
+
+## Docker
+```bash
+docker compose up --build
+```

--- a/services/FraudDetection/app/main.py
+++ b/services/FraudDetection/app/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Fraud Detection API", version="v1")
+
+class OrderInfo(BaseModel):
+    order_id: str
+    user_ip: str
+    device_fingerprint: str
+
+class FraudResult(BaseModel):
+    order_id: str
+    suspicious: bool
+
+@app.post("/fraud/check", response_model=FraudResult)
+async def check_fraud(info: OrderInfo):
+    # Dummy rules placeholder
+    suspicious = info.user_ip.startswith("192.0.2.")
+    return FraudResult(order_id=info.order_id, suspicious=suspicious)
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}

--- a/services/FraudDetection/pyproject.toml
+++ b/services/FraudDetection/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "frauddetection"
+version = "0.1.0"
+description = "Fraud Detection service"
+authors = ["Example <example@example.com>"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+scikit-learn = "^1.4"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+pytest-asyncio = "^0.23"
+httpx = "^0.27"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/PaymentGateway/Dockerfile
+++ b/services/PaymentGateway/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
+        --default-timeout=120 poetry && \
+    poetry config virtualenvs.create false && \
+    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
+    poetry install --no-interaction --no-ansi --no-root
+COPY app ./app
+RUN poetry install --no-interaction --no-ansi
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/PaymentGateway/README.md
+++ b/services/PaymentGateway/README.md
@@ -1,0 +1,14 @@
+# Payment Gateway Orchestrator
+
+Aggregates providers like Stripe and PayPal and applies simple retry logic. This example exposes minimal FastAPI endpoints.
+
+## Development
+```bash
+poetry install
+poetry run uvicorn app.main:app --reload
+```
+
+## Docker
+```bash
+docker compose up --build
+```

--- a/services/PaymentGateway/app/main.py
+++ b/services/PaymentGateway/app/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import httpx
+from tenacity import retry, stop_after_attempt
+
+app = FastAPI(title="Payment Gateway API", version="v1")
+
+class PaymentRequest(BaseModel):
+    provider: str
+    amount: float
+
+class PaymentResponse(BaseModel):
+    status: str
+    provider: str
+
+@retry(stop=stop_after_attempt(3))
+async def call_provider(provider: str, payload: dict) -> dict:
+    # Simulate provider call; in reality would route to Stripe/PayPal/etc
+    # Here we just echo the provider name
+    return {"ok": True, "provider": provider}
+
+@app.post("/pay", response_model=PaymentResponse)
+async def pay(req: PaymentRequest):
+    result = await call_provider(req.provider, req.model_dump())
+    return PaymentResponse(status="success" if result.get("ok") else "failed", provider=result["provider"])
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}

--- a/services/PaymentGateway/pyproject.toml
+++ b/services/PaymentGateway/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "paymentgateway"
+version = "0.1.0"
+description = "Payment Gateway Orchestrator service"
+authors = ["Example <example@example.com>"]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110"
+uvicorn = "^0.29"
+httpx = "^0.27"
+tenacity = "^8.2"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2"
+pytest-asyncio = "^0.23"
+httpx = "^0.27"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -314,6 +314,42 @@ services:
     ports:
       - "9040:8000"
 
+  paymentgateway.api:
+    build:
+      context: ./PaymentGateway
+      dockerfile: Dockerfile
+    image: ${REGISTRY}paymentgateway.api:dev
+    container_name: paymentgateway-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9050:8000"
+
+  frauddetection.api:
+    build:
+      context: ./FraudDetection
+      dockerfile: Dockerfile
+    image: ${REGISTRY}frauddetection.api:dev
+    container_name: frauddetection-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9060:8000"
+
+  consent.api:
+    build:
+      context: ./Consent
+      dockerfile: Dockerfile
+    image: ${REGISTRY}consent.api:dev
+    container_name: consent-api
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "9070:8000"
+
   admin.api:
     build:
       context: ./Admin
@@ -363,6 +399,9 @@ services:
       - currency.api
       - address.api
       - shippingrate.api
+      - paymentgateway.api
+      - frauddetection.api
+      - consent.api
     ports:
       - "8000:8000"
       - "8443:8443"


### PR DESCRIPTION
## Summary
- add minimal PaymentGateway, FraudDetection and Consent FastAPI microservices
- update docker-compose to run the new services and expose ports
- update gateway dependencies for the new services
- document the additional services in README

## Testing
- `docker --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68839a2f13b4832e83c73ca974f95de9