### PR TITLE
Use multi-stage builds for Python services

### DIFF
--- a/services/Address/Dockerfile
+++ b/services/Address/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Admin/Dockerfile
+++ b/services/Admin/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Analytics/Dockerfile
+++ b/services/Analytics/Dockerfile
@@ -1,22 +1,17 @@
-# 1. Use a Python version matching pyproject.toml
-FROM python:3.12-slim
-
-# 2. Install Poetry from a Chinese mirror
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
-
-# 3. Install third-party dependencies first (no root package)
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml poetry.lock ./
-RUN poetry config virtualenvs.create false \
- && poetry config repositories.tuna https://pypi.tuna.tsinghua.edu.cn/simple \
- && poetry install --no-interaction --no-ansi --no-root
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
+    --default-timeout=120 poetry && \
+    poetry config virtualenvs.create false && \
+    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
+    poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
 
-
-# 4. Copy source code and install root package
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi              # install root package
-
-# 5. Run the service
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Asset/Dockerfile
+++ b/services/Asset/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Attribute/Dockerfile
+++ b/services/Attribute/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Bff/Dockerfile
+++ b/services/Bff/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Cms/Dockerfile
+++ b/services/Cms/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Consent/Dockerfile
+++ b/services/Consent/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Currency/Dockerfile
+++ b/services/Currency/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/DataWarehouse/Dockerfile
+++ b/services/DataWarehouse/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Experiment/Dockerfile
+++ b/services/Experiment/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Facet/Dockerfile
+++ b/services/Facet/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Forecasting/Dockerfile
+++ b/services/Forecasting/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/FraudDetection/Dockerfile
+++ b/services/FraudDetection/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Inventory/Dockerfile
+++ b/services/Inventory/Dockerfile
@@ -1,15 +1,12 @@
+FROM python:3.11-slim AS build
+WORKDIR /app
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
 FROM python:3.11-slim
 WORKDIR /app
-
-COPY pyproject.toml poetry.lock ./
-
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --only main --no-root -vvv
-
-
-COPY app ./app
-
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Moderation/Dockerfile
+++ b/services/Moderation/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Notification/Dockerfile
+++ b/services/Notification/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml poetry.lock ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/PaymentGateway/Dockerfile
+++ b/services/PaymentGateway/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Performance/Dockerfile
+++ b/services/Performance/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Promotion/Dockerfile
+++ b/services/Promotion/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Recommendation/Dockerfile
+++ b/services/Recommendation/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Review/Dockerfile
+++ b/services/Review/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Rma/Dockerfile
+++ b/services/Rma/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Search/Dockerfile
+++ b/services/Search/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Seo/Dockerfile
+++ b/services/Seo/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry && \
-    poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
 COPY app ./app
-RUN poetry install --no-interaction --no-ansi
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/ShippingRate/Dockerfile
+++ b/services/ShippingRate/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Tax/Dockerfile
+++ b/services/Tax/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Tenant/Dockerfile
+++ b/services/Tenant/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Ticketing/Dockerfile
+++ b/services/Ticketing/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/Wishlist/Dockerfile
+++ b/services/Wishlist/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.12-slim
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
-        --default-timeout=120 poetry
+FROM python:3.12-slim AS build
 WORKDIR /app
-COPY pyproject.toml ./
-RUN poetry config virtualenvs.create false && \
-    poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi --no-root
-COPY ./app ./app
-RUN poetry install --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock* ./
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+COPY app ./app
+RUN poetry build -f wheel
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=build /app/dist/*.whl .
+RUN pip install --no-cache-dir *.whl && rm *.whl
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- move all Python microservices to multi-stage Dockerfiles so runtime images only contain built wheels

## Testing
- `npm ci --legacy-peer-deps`
- `npm test --silent`
- `poetry run pytest -q` in Admin, Analytics and Inventory
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a7f948f0832eac424ac2f9472d3a