### PR TITLE
Fix GHCR tag casing

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Build and push
         run: |
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          name=$(echo "${{ matrix.service }}" | tr '[:upper:]' '[:lower:]')
           if [ "${{ matrix.service }}" = "Frontend" ]; then
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
@@ -52,7 +53,7 @@ jobs:
           else
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
-              -t ghcr.io/$owner/${{ matrix.service }}.api:latest \
+              -t ghcr.io/$owner/$name.api:latest \
               --push \
               -f services/${{ matrix.service }}/Dockerfile services/${{ matrix.service }}
           fi

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -10,7 +10,7 @@ Each service folder under `services/` produces an image named:
 ghcr.io/<owner>/<service>.api:latest
 ```
 
-Where `<owner>` is your GitHub user or organisation and `<service>` matches the directory name (for example `Catalog`).
+Where `<owner>` is your GitHub user or organisation and `<service>` matches the service directory name. Image repositories on GHCR must be lowercase, so the workflow automatically converts the service name to lowercase when tagging (for example `Catalog` becomes `catalog`).
 
 The frontend image is built from the `frontend` directory as:
 


### PR DESCRIPTION
## Summary
- lowercase the service name when tagging docker images in the workflow
- clarify in the docs that image names are lowercased

## Testing
- `npm test --silent` in `frontend`
- `poetry run pytest -q` in `services/Admin`


------
https://chatgpt.com/codex/tasks/task_e_68844fb936c8832ea7be392c3e111f26