### PR TITLE
Fix JWT secret config

### DIFF
--- a/services/Gateway/kong.yml
+++ b/services/Gateway/kong.yml
@@ -5,12 +5,14 @@ consumers:
     jwt_secrets:
       - key: frontend
         secret: myfrontendsecret
+        algorithm: HS256
     acls:
       - group: frontend-group
   - username: admin
     jwt_secrets:
       - key: admin
         secret: myadminsecret
+        algorithm: HS256
     acls:
       - group: admin-group
   


### PR DESCRIPTION
## Summary
- add mandatory algorithm field to jwt secrets in Kong config

## Testing
- `pytest -q` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68846a0d1ef4832eb534f32754776f73