### PR TITLE
Fix Docker builds by skipping project install in Poetry

### DIFF
--- a/services/Address/Dockerfile
+++ b/services/Address/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Admin/Dockerfile
+++ b/services/Admin/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Analytics/Dockerfile
+++ b/services/Analytics/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple \
     --default-timeout=120 poetry && \
     poetry config virtualenvs.create false && \
     poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple && \
-    poetry install --no-interaction --no-ansi
+    poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Asset/Dockerfile
+++ b/services/Asset/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Attribute/Dockerfile
+++ b/services/Attribute/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Bff/Dockerfile
+++ b/services/Bff/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Cms/Dockerfile
+++ b/services/Cms/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Consent/Dockerfile
+++ b/services/Consent/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Currency/Dockerfile
+++ b/services/Currency/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/DataWarehouse/Dockerfile
+++ b/services/DataWarehouse/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Experiment/Dockerfile
+++ b/services/Experiment/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Facet/Dockerfile
+++ b/services/Facet/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Forecasting/Dockerfile
+++ b/services/Forecasting/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/FraudDetection/Dockerfile
+++ b/services/FraudDetection/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Inventory/Dockerfile
+++ b/services/Inventory/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Moderation/Dockerfile
+++ b/services/Moderation/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Notification/Dockerfile
+++ b/services/Notification/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/PaymentGateway/Dockerfile
+++ b/services/PaymentGateway/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Performance/Dockerfile
+++ b/services/Performance/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Promotion/Dockerfile
+++ b/services/Promotion/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Recommendation/Dockerfile
+++ b/services/Recommendation/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Review/Dockerfile
+++ b/services/Review/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Rma/Dockerfile
+++ b/services/Rma/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Search/Dockerfile
+++ b/services/Search/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Seo/Dockerfile
+++ b/services/Seo/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/ShippingRate/Dockerfile
+++ b/services/ShippingRate/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Tax/Dockerfile
+++ b/services/Tax/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Tenant/Dockerfile
+++ b/services/Tenant/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Ticketing/Dockerfile
+++ b/services/Ticketing/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 

--- a/services/Wishlist/Dockerfile
+++ b/services/Wishlist/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim AS build
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple         --default-timeout=120 poetry &&         poetry config virtualenvs.create false &&         poetry config repositories.aliyun https://mirrors.aliyun.com/pypi/simple &&         poetry install --no-interaction --no-ansi --no-root
 COPY app ./app
 RUN poetry build -f wheel
 


### PR DESCRIPTION
## Summary
- prevent Poetry from failing during Docker image build by skipping root package install

## Testing
- `poetry install -n && poetry run pytest -q` in `services/Admin`
- `poetry install -n && poetry run pytest -q` in `services/Analytics`
- `poetry install -n && poetry run pytest -q` in `services/Inventory`


------
https://chatgpt.com/codex/tasks/task_e_68847925a098832e8c796722ba0c2fd6