### PR TITLE
fix: adjust dashboard grid for MUI 7

### DIFF
--- a/apps/merchant/src/views/Dashboard.tsx
+++ b/apps/merchant/src/views/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, Typography, Grid } from '@mui/material'
+import { Card, CardContent, Typography } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 
 export default function Dashboard() {
   return (


### PR DESCRIPTION
## Summary
- adjust merchant dashboard grid to use `GridLegacy` for MUI v7 compatibility

## Testing
- `cd apps/merchant && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bcfd6994a4832eaeca5e5b087dbae0