### PR TITLE
fix: validate Kong ACL plugin configuration

### DIFF
--- a/services/Gateway/kong.yml
+++ b/services/Gateway/kong.yml
@@ -1,3 +1,4 @@
+---
 _format_version: '3.0'
 _transform: true
 consumers:
@@ -15,7 +16,7 @@ consumers:
         algorithm: HS256
     acls:
       - group: admin-group
-  
+
 services:
   - name: catalog
     protocol: http
@@ -212,6 +213,10 @@ services:
         enabled: false
       - name: acl
         enabled: false
+        config:
+          allow:
+            - frontend-group
+            - admin-group
 
   - name: security
     protocol: http
@@ -256,9 +261,3 @@ plugins:
       minute: 60
       policy: local
   - name: prometheus
-
-
-
-
-
-


### PR DESCRIPTION
## Summary
- ensure auth service ACL plugin includes required config
- tidy Gateway kong.yml formatting

## Testing
- `yamllint services/Gateway/kong.yml`
- `/tmp/deck file validate services/Gateway/kong.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c4f8e8c832eaa7c3a85a276b1da