### PR TITLE
Fix decK sync command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             exit 1
           fi
       - name: Sync Kong config
-        run: deck gateway sync --state services/Gateway/kong.yml --kong-addr http://127.0.0.1:8001
+        run: deck gateway sync services/Gateway/kong.yml --kong-addr http://127.0.0.1:8001
       - name: Stop Kong Gateway
         run: docker rm -f kong-test
       - name: Set lowercase registry


### PR DESCRIPTION
## Summary
- fix decK gateway sync step to use new CLI syntax

## Testing
- `./deck file validate services/Gateway/kong.yml`
- `./deck gateway sync services/Gateway/kong.yml --kong-addr http://127.0.0.1:8001` *(fails: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1f895c14832eb2dc7ccfaac7d352