### PR TITLE
fix: remove unused useEffect import

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from 'react'
+﻿import { useState } from 'react'
 import { Container, TextField, Button, Typography, Stack } from '@mui/material'
 import api from '../api/api'
 import { useSnackbar } from '../providers/SnackbarProvider'


### PR DESCRIPTION
## Summary
- remove unused `useEffect` import from login page causing TypeScript error

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd30ea3624832ebe2c4c31dce26711